### PR TITLE
FRONTEND:: add the 'darwin_mode' parameter, and fix to JS

### DIFF
--- a/vulture_os/gui/static/js/listener.js
+++ b/vulture_os/gui/static/js/listener.js
@@ -259,11 +259,13 @@ $(function() {
     }
   }
 
-  function refresh_input_logs_type(listening_mode){
+  function refresh_input_logs_type(mode, listening_mode){
     var first = true;
-    $('#ruleset-div').show();
-    $('#id_node').show();
-    if (listening_mode === "api"){
+    if(mode === "log" && listening_mode !== "api") {
+      $('#ruleset-div').show();
+      $('#id_node').show();
+    }
+    else {
       $('#ruleset-div').hide();
       $('#id_node').hide();
     }
@@ -356,7 +358,7 @@ $(function() {
         $('#stock_logs_locally').click();
       }
 
-      refresh_input_logs_type($('#id_listening_mode').val());
+      refresh_input_logs_type(mode, $('#id_listening_mode').val());
     }
     if( mode === "impcap" ) {
       toggle_impcap_filter_type();
@@ -427,7 +429,7 @@ $(function() {
     show_custom_conf($('#id_mode').val(), $(this).val());
     show_listening_mode($('#id_mode').val(), $(this).val());
     show_network_conf($('#id_mode').val(), $(this).val());
-    refresh_input_logs_type($(this).val());
+    refresh_input_logs_type($('#id_mode').val(), $(this).val());
   }).trigger('change');
 
 

--- a/vulture_os/gui/static/js/listener.js
+++ b/vulture_os/gui/static/js/listener.js
@@ -271,6 +271,15 @@ $(function() {
     }
   }
 
+  function show_darwin_mode(darwin_policy) {
+    if( darwin_policy ) {
+      $('.darwin-mode').show();
+    }
+    else {
+      $('.darwin-mode').hide();
+    }
+  }
+
   $('#id_api_parser_type').on('change', function(){
     refresh_api_parser_type($(this).val());
   }).trigger('change');
@@ -391,6 +400,11 @@ $(function() {
       }
     }
   }).trigger("change");
+
+  $('#id_darwin_policy').on("change", function(e) {
+    var policy = $(this).val();
+    show_darwin_mode(policy);
+  }).trigger('change');
 
 
   /* Show log_condition_failure depending on mode and ruleset */

--- a/vulture_os/services/frontend/form.py
+++ b/vulture_os/services/frontend/form.py
@@ -119,12 +119,6 @@ class FrontendForm(ModelForm):
             widget=Select(attrs={'class': 'form-control select2'}),
             required=False
         )
-        """ Darwin mode """
-        self.fields['darwin_mode'] = ChoiceField(
-            label=_("Darwin mode"),
-            choices=DARWIN_MODE_CHOICES,
-            widget=Select(attrs={'class': 'form-control select2'})
-        )
         """ Log forwarders """
         self.fields['log_forwarders'] = ModelMultipleChoiceField(
             label=_("Log forwarders"),
@@ -270,6 +264,7 @@ class FrontendForm(ModelForm):
             'impcap_intf': Select(choices=NetworkInterfaceCard.objects.all(), attrs={'class': "form-control select2"}),
             'enable_logging_reputation': CheckboxInput(attrs={'class': "js-switch"}),
             'log_level': Select(choices=LOG_LEVEL_CHOICES, attrs={'class': 'form-control select2'}),
+            'darwin_mode': Select(choices=DARWIN_MODE_CHOICES, attrs={'class': 'form-control select2'}),
             'log_condition': Textarea(attrs={'class': 'form-control'}),
             'ruleset': Select(attrs={'class': 'form-control select2'}),
             'listening_mode': Select(choices=LISTENING_MODE_CHOICES, attrs={'class': 'form-control select2'}),

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -98,6 +98,11 @@ IMPCAP_FILTER_CHOICES = (
     ('custom', "Custom"),
 )
 
+DARWIN_MODE_CHOICES = (
+    ('darwin', "generate alerts"),
+    ('both', "enrich logs and generate alerts")
+)
+
 # Jinja template for frontends rendering
 JINJA_PATH = "/home/vlt-os/vulture_os/services/frontend/config/"
 JINJA_TEMPLATE = "haproxy_frontend.conf"
@@ -178,6 +183,8 @@ class Frontend(models.Model):
         verbose_name=_("Impcap filter"),
         help_text=_("Filter used by impcap for trafic listening (tcpdump format)")
     )
+    """ *** DARWIN OPTIONS *** """
+    """ Darwin policy """
     darwin_policy = models.ForeignKey(
         to=DarwinPolicy,
         on_delete=models.PROTECT,
@@ -185,6 +192,12 @@ class Frontend(models.Model):
         blank=False,
         related_name="frontend_set",
         help_text=_("Darwin policy to use")
+    )
+    """ Darwin mode """
+    darwin_mode = models.TextField(
+        default=DARWIN_MODE_CHOICES[0][0],
+        choices=DARWIN_MODE_CHOICES,
+        help_text=_("Ways to call Darwin: 'enrich' will wait for a score and add it to the data, 'alert' will simply pass the data for Darwin to process and will rely on its configured alerting methods")
     )
     """ *** LOGGING OPTIONS *** """
     """ Enable logging to Rsyslog """
@@ -838,6 +851,7 @@ class Frontend(models.Model):
             'serialized_blwl_list': serialized_blwl_list,
             'darwin_policies': FilterPolicy.objects.filter(policy=self.darwin_policy),
             'keep_source_fields': self.keep_source_fields,
+            'darwin_mode': self.darwin_mode,
         }
 
         if self.mode == "impcap":

--- a/vulture_os/services/rsyslogd/config/rsyslog_darwin/ruleset.conf
+++ b/vulture_os/services/rsyslogd/config/rsyslog_darwin/ruleset.conf
@@ -12,7 +12,7 @@
         action(type="mmdarwin"
            key="dga"
            socketpath="{{ darwin_policy.socket_path }}"
-           response="no"
+           response="{{ frontend.darwin_mode }}"
            fields=["!tmp3"]
            socket_max_use="5")
     }
@@ -23,7 +23,7 @@
         action(type="mmdarwin"
            key="hostlookup"
            socketpath="{{ darwin_policy.socket_path }}"
-           response="no"
+           response="{{ frontend.darwin_mode }}"
            fields=["!tmp3"]
            socket_max_use="5")
     }
@@ -33,7 +33,7 @@
         action(type="mmdarwin"
             key="content_inspection"
             socketpath="{{ darwin_policy.socket_path }}"
-            response="no"
+            response="{{ frontend.darwin_mode }}"
             fields=["!impcap", "!data"]
             socket_max_use="10")
     }
@@ -43,7 +43,7 @@
             socketpath="{{ darwin_policy.socket_path }}"
             fields=["!darwin_src_ip", "!darwin_dst_ip", "!darwin_dst_port", "!darwin_IP_proto"]
             key="tanomaly"
-            response="no"
+            response="{{ frontend.darwin_mode }}"
             socket_max_use="5")
 
     {%- elif darwin_policy.filter.name == "connection" %}
@@ -51,7 +51,7 @@
             socketpath="{{ darwin_policy.socket_path }}"
             fields=["!darwin_src_ip", "!darwin_dst_ip", "!darwin_dst_port", "!darwin_IP_proto"]
             key="connection"
-            response="no"
+            response="{{ frontend.darwin_mode }}"
             socket_max_use="5")
 
     {%- endif %}

--- a/vulture_os/services/templates/services/frontend_edit.html
+++ b/vulture_os/services/templates/services/frontend_edit.html
@@ -235,7 +235,18 @@
                           </div>
                         </div>
                       </div>
-                    </div> <!-- /.row impcap-mode -->
+                      <div class="darwin-mode">
+                        <div class="col-md-12">
+                          <div class="form-group">
+                            <label class="col-sm-4 control-label">{% trans "Darwin mode" %}</label>
+                            <div class="col-sm-5">
+                              {{form.darwin_mode}}
+                              {{form.darwin_mode.errors|safe}}
+                            </div>
+                          </div>
+                        </div>
+                      </div> <!-- /.row darwin-mode -->
+                    </div> <!-- /.row -->
                   </div> <!-- /.tab-pane -->
                   <div class="tab-pane" id="tab_network">
 


### PR DESCRIPTION
- add a 'darwin_mode' parameter when a darwin policy is added to a Listener
- 'darwin_mode' has 2 options:
  - 'generate alerts' (mmdarwin 'darwin'), sends data to the filter and doesn't wait for an answer (data is propagated to potential chained filters)
  - 'enrich logs and generate alerts' (mmdarwin 'both'), waits for the filter to reply with the certitude(s) (data is propagated to chained filters)

- fix 'input_log_type' parameter to only show for the right mode