### PR TITLE
WORFLOW:: FIXES TO ACLS AND CERTIFICATE LOAD

### DIFF
--- a/vulture_os/services/frontend/config/haproxy_frontend.conf
+++ b/vulture_os/services/frontend/config/haproxy_frontend.conf
@@ -98,6 +98,7 @@ cache cache_{{ conf.id }}
     {%- for workflow in conf.workflows %}
     {%- if workflow.backend.mode == "http" %}
     acl workflow_{{workflow.id}}_host hdr(host) {{workflow.fqdn}}
+    acl workflow_{{workflow.id}}_host hdr(host) -m beg {{workflow.fqdn}}:
     acl workflow_{{workflow.id}}_dir path -i -m beg {{ workflow.public_dir }}
     {%- endif -%}
     {% endfor %}

--- a/vulture_os/system/pki/models.py
+++ b/vulture_os/system/pki/models.py
@@ -582,7 +582,7 @@ class TLSProfile(models.Model):
 
     def generate_conf(self, backend=False):
         """ Most important : the cert """
-        result = " ssl crt {}".format(self.x509_certificate.get_base_filename() + ".pem")
+        result = " ssl crt '{}'".format(self.x509_certificate.get_base_filename() + ".pem")
         """ ALPN is not compatible with Backend """
         if not backend:
             """ Add list of ALPN """


### PR DESCRIPTION
- ACL: allow Host header with a  custom explicit port (example: allow both 'vulture.local' and 'vulture.local:1234')
- Listener with TLS profile: fix bug when using certificate with spaces in name