### PR TITLE
HAPROXY CONF::CHANGE:: put IPv6 addresses in brackets

### DIFF
--- a/vulture_os/applications/backend/models.py
+++ b/vulture_os/applications/backend/models.py
@@ -631,7 +631,7 @@ class Server(models.Model):
         :return     A string - Bind directive
         """
         result = "server srv{} {}{} weight {}".format(self.id or get_random_string(),
-                                                       self.target,
+                                                       "[{}]".format(self.target) if ":" in self.target else self.target,
                                                        ":" + str(self.port) if self.mode == "net" else "",
                                                        self.weight)
         if self.source:

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -1559,7 +1559,12 @@ class Listener(models.Model):
         """ Generate Listener HAProxy configuration
         :return     A string - Bind directive
         """
-        result = "bind {}:{}".format(JAIL_ADDRESSES['haproxy'][self.network_address.family], self.rsyslog_port)
+        if self.network_address.family == "inet6":
+            address = "[{}]".format(JAIL_ADDRESSES['haproxy'][self.network_address.family])
+        else:
+            address = JAIL_ADDRESSES['haproxy'][self.network_address.family]
+
+        result = "bind {}:{}".format(address, self.rsyslog_port)
         if self.tls_profiles:
             for tls_profile in self.tls_profiles.all():
                 result += tls_profile.generate_conf() + " "


### PR DESCRIPTION
- Changed Haproxy configuration generation to enclose IPv6 addresses in brackets 