### PR TITLE
GUI_DARWIN::MODIFIED:: Can always set enrichment tags to a filter, those tags will always be in the alert

### DIFF
--- a/vulture_os/darwin/policy/models.py
+++ b/vulture_os/darwin/policy/models.py
@@ -903,6 +903,9 @@ class FilterPolicy(models.Model):
             'log_file_path': ALERTS_LOG_FILEPATH
         }
 
+        if self.enrichment_tags:
+            json_conf['alert_tags'] = self.enrichment_tags
+
         # Those fields were already validated and don't need any modification, let them be in the resulting configuration as-is
         PASS_THROUGH_FIELDS = ['redis_expire', 'max_tokens', 'fastmode', 'timeout', 'redis_socket_path',
                                 'alert_redis_list_name', 'alert_redis_channel_name', 'log_file_path',

--- a/vulture_os/darwin/templates/policy_edit_v2.html
+++ b/vulture_os/darwin/templates/policy_edit_v2.html
@@ -224,7 +224,7 @@
                   </div>
                 </template>
 
-                <div class="col-md-12 form-group" v-if="!filter.continuous_analysis_enabled">
+                <div class="col-md-12 form-group">
                     <label class="col-sm-4 control-label">{% trans "Additional Rsyslog enrichment tags" %}:</label>
                     <div class="col-sm-5">
                       <vue-tags-input

--- a/vulture_os/gui/static/js/darwin_policy_edit.js
+++ b/vulture_os/gui/static/js/darwin_policy_edit.js
@@ -238,7 +238,7 @@ function init_vue(){
           rsyslog_params += `<p><b>${gettext("Overriden Rsyslog inputs")}:</b> ${tmp.join(' ')}</p>`
         }
 
-        if (filter.enrichment_tags.length > 0 && !filter.continuous_analysis_enabled){
+        if (filter.enrichment_tags.length > 0){
           let tmp = []
 
           for (let tag of filter.enrichment_tags)
@@ -602,7 +602,7 @@ function init_vue(){
             buffering.interval = tmp_filter.buffering.interval
             buffering.required_log_lines = tmp_filter.buffering.required_log_lines
           }
-          else {
+          if (tmp_filter.enrichment_tags.length > 0) {
               for (let tmp of tmp_filter.enrichment_tags)
                 enrichment_tags.push(tmp.text)
           }


### PR DESCRIPTION
## Modified
- [GUI] [Darwin] enrichment tags are always available and can always be set
- [GUI] [Darwin] if enrichment tags are set on a filter, those tags will always be in the generated alerts