### PR TITLE
IPSEC:: various fixes and improvements

### DIFF
--- a/vulture_os/daemons/monitor.py
+++ b/vulture_os/daemons/monitor.py
@@ -174,6 +174,7 @@ def monitor():
             default = ("ERROR", str(e))
             statusall, tunnel_statuses, ups, connectings = "ERROR", {}, 0, 0
 
+        strongswan.tunnels_status = {}
         for network in strongswan.ipsec_rightsubnet.split(','):
             strongswan.tunnels_status[network] = tunnel_statuses.get(network, default)
             logger.debug("Status of IPSEC Tunnel '{}' : {}".format(network, strongswan.tunnels_status[network]))

--- a/vulture_os/services/strongswan/api.py
+++ b/vulture_os/services/strongswan/api.py
@@ -42,6 +42,7 @@ logger = logging.getLogger('api')
 class StrongswanAPIv1(View):
     @api_need_key('cluster_api_key')
     def get(self, request, object_id=None):
+        node_id = request.GET.get("node")
         try:
             if object_id:
                 try:
@@ -50,13 +51,19 @@ class StrongswanAPIv1(View):
                     return JsonResponse({
                         'error': _('Object does not exist')
                     }, status=404)
-
+            elif node_id:
+                obj = Strongswan.objects.get(node__pk=node_id).to_dict()
             else:
                 obj = [s.to_dict() for s in Strongswan.objects.all()]
 
             return JsonResponse({
                 'data': obj
             })
+
+        except (Strongswan.DoesNotExist, Node.DoesNotExist):
+            return JsonResponse({
+                "error": _("Object not found")
+            }, status=404)
 
         except Exception as e:
             logger.critical(e, exc_info=1)

--- a/vulture_os/services/strongswan/models.py
+++ b/vulture_os/services/strongswan/models.py
@@ -96,6 +96,9 @@ class Strongswan(models.Model):
     tunnels_up = models.PositiveIntegerField(default=0)
     tunnels_connecting = models.PositiveIntegerField(default=0)
 
+    def __str__(self):
+        return f"Ipsec configuration"
+
     def to_template(self):
         """ Dictionary used to create configuration file.
 
@@ -108,6 +111,7 @@ class Strongswan(models.Model):
         return {
             'id': str(self.id),
             'node': self.node.to_dict(),
+            'enabled': self.enabled,
             'status': self.status,
             'statusall': self.statusall,
             'ipsec_type': self.ipsec_type,

--- a/vulture_os/services/strongswan/urls.py
+++ b/vulture_os/services/strongswan/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
         name="services.strongswan.api"
     ),
 
-    path('api/v1/services/strongswan/<int:object_id>',
+    path('api/v1/services/strongswan/<int:object_id>/',
         api.StrongswanAPIv1.as_view(),
         name="services.strongswan.api"
     ),

--- a/vulture_os/services/strongswan/views.py
+++ b/vulture_os/services/strongswan/views.py
@@ -119,7 +119,7 @@ def strongswan_delete(request, object_id, api=False):
     })
 
 
-def strongswan_edit(request, object_id, api=False, update=False):
+def strongswan_edit(request, object_id=None, api=False, update=False):
     strongswan = None
     if object_id:
         try:


### PR DESCRIPTION
## Added
- [IPSEC] [GUI] default name "Ipsec configuration" for ipsec objects
- [IPSEC] [API] 'enabled' field is returned in object's data
- [IPSEC] [API] can get an Ipsec configuration with its related node id

## FIxed
- [IPSEC] [GUI + API] Could not create a new configuration
- [IPSEC] [SERVICE] no old tunnel statuses remain after a refresh