### PR TITLE
Version 1.2.9

### DIFF
--- a/vulture_os/authentication/generic_delete.py
+++ b/vulture_os/authentication/generic_delete.py
@@ -129,7 +129,7 @@ class DeleteLDAPRepository(DeleteView):
     delete_url = "/authentication/ldap/delete/"
 
     def used_by(self, object):
-        return ["Workflow " + w.name for w in UserAuthentication.objects.filter(repositories=object)]
+        return ["Portal " + w.name for w in UserAuthentication.objects.filter(repositories=object)]
 
     # get, post and used_by methods herited from mother class
 

--- a/vulture_os/authentication/ldap/tools.py
+++ b/vulture_os/authentication/ldap/tools.py
@@ -207,9 +207,12 @@ def delete_user(ldap_repository, user_dn):
     group_dn = f"{ldap_repository.group_dn},{ldap_repository.base_dn}"   
     client = ldap_repository.get_client()
 
-    old_user = find_user(ldap_repository, user_dn, ["*"])
-    if not old_user:
-        raise UserNotExistError()
+    try:
+        old_user = find_user(ldap_repository, user_dn, ["*"])
+        if not old_user:
+            raise UserNotExistError()
+    except IndexError:
+            raise UserNotExistError()
 
     groups = [find_group(ldap_repository, group_dn, ["*"]) for group_dn in client.search_user_groups_by_dn(user_dn)]
     r = client.delete_user(user_dn, groups)

--- a/vulture_os/authentication/openid/form.py
+++ b/vulture_os/authentication/openid/form.py
@@ -78,5 +78,8 @@ class OpenIDRepositoryForm(ModelForm):
     def clean_scopes(self):
         scopes = self.cleaned_data.get('scopes')
         if scopes:
-            return [i.replace(" ", "") for i in scopes.split(',')]
+            if isinstance(scopes, list):
+                return [i.replace(" ", "") for i in scopes]
+            else:
+                return [i.replace(" ", "") for i in scopes.split(',')]
         return []

--- a/vulture_os/authentication/openid/models.py
+++ b/vulture_os/authentication/openid/models.py
@@ -170,7 +170,11 @@ class OpenIDRepository(BaseRepository):
         return provider_type
 
     def to_dict(self):
-        return model_to_dict(self)
+        ret = model_to_dict(self)
+        # model_to_dict will not return a list if the field only contains 1 value
+        if not isinstance(ret['scopes'], list):
+            ret['scopes'] = [ret['scopes']]
+        return ret
 
     def to_template(self):
         """ Returns the attributes of the class """

--- a/vulture_os/authentication/openid/views.py
+++ b/vulture_os/authentication/openid/views.py
@@ -81,7 +81,11 @@ def edit(request, object_id=None, api=False):
             return HttpResponseForbidden("Injection detected")
 
     if hasattr(request, "JSON") and api:
-        form = OpenIDRepositoryForm(request.JSON or None, instance=repo, error_class=DivErrorList)
+        data = request.JSON
+        # Format scopes correctly for form
+        if data:
+            data['scopes'] = ','.join(data.get('scopes', ''))
+        form = OpenIDRepositoryForm(data, instance=repo, error_class=DivErrorList)
     else:
         form = OpenIDRepositoryForm(request.POST or None, instance=repo, error_class=DivErrorList)
 

--- a/vulture_os/authentication/openid/views.py
+++ b/vulture_os/authentication/openid/views.py
@@ -81,11 +81,7 @@ def edit(request, object_id=None, api=False):
             return HttpResponseForbidden("Injection detected")
 
     if hasattr(request, "JSON") and api:
-        data = request.JSON
-        # Format scopes correctly for form
-        if data:
-            data['scopes'] = ','.join(data.get('scopes', ''))
-        form = OpenIDRepositoryForm(data, instance=repo, error_class=DivErrorList)
+        form = OpenIDRepositoryForm(request.JSON or None, instance=repo, error_class=DivErrorList)
     else:
         form = OpenIDRepositoryForm(request.POST or None, instance=repo, error_class=DivErrorList)
 

--- a/vulture_os/authentication/user_portal/views.py
+++ b/vulture_os/authentication/user_portal/views.py
@@ -43,6 +43,7 @@ from system.cluster.models  import Cluster
 from system.pki.models import X509Certificate, PROTOCOLS_TO_INT
 from portal.system.sso_clients import SSOClient
 from toolkit.http.utils import parse_html
+from toolkit.system.hashes import random_sha256
 from authentication.openid.models import OpenIDRepository
 
 # Extern modules imports
@@ -77,10 +78,20 @@ def user_authentication_clone(request, object_id):
         return HttpResponseNotFound("Object not found")
 
     profile.pk = None
+    profile.oauth_client_id = random_sha256
+    profile.oauth_client_secret = random_sha256
     profile.name = "Copy_of_" + str(profile.name)
 
+    repo_attrs_form_list = []
+    for p in profile.get_repo_attributes():
+        repo_attrs_form_list.append(RepoAttributesForm(instance=p))
+
     form = UserAuthenticationForm(None, instance=profile, error_class=DivErrorList)
-    return render(request, 'authentication/user_authentication_edit.html', {'form': form})
+    return render(request, 'authentication/user_authentication_edit.html', {
+        'form': form,
+        'repo_attributes': repo_attrs_form_list,
+        'repo_attribute_form': RepoAttributesForm()
+        })
 
 
 def user_authentication_edit(request, object_id=None, api=False):

--- a/vulture_os/authentication/user_portal/views.py
+++ b/vulture_os/authentication/user_portal/views.py
@@ -185,11 +185,14 @@ def user_authentication_edit(request, object_id=None, api=False):
                         workflow.frontend.reload_conf()
                 if profile.enable_external:
                     # Automatically create OpenID repo
-                    openid_repo, created = OpenIDRepository.objects.get_or_create(client_id=profile.oauth_client_id,
-                                                                                  client_secret=profile.oauth_client_secret,
-                                                                                  provider="openid")
+                    openid_repo, _ = OpenIDRepository.objects.get_or_create( client_id=profile.oauth_client_id,
+                                                            client_secret=profile.oauth_client_secret,
+                                                            provider="openid",
+                                                            defaults={
+                                                                'provider_url': f"https://{profile.external_fqdn}",
+                                                                'name': "Connector_{}".format(profile.name)
+                                                            })
                     openid_repo.provider_url = f"https://{profile.external_fqdn}"
-                    openid_repo.name = "Connector_{}".format(profile.name)
                     openid_repo.save()
                     # Reload old external_listener conf if has changed
                     if external_listener_changed:


### PR DESCRIPTION
## Fixed
- [IDP] [PROVISIONING] return 404 if user does not exist during deletion
- [USER PORTAL] [GUI] preserve scopes during portal copies
- [OPENID] [API] allow giving scopes as json array
- [IDP PORTAL] Don't overwrite Connector name when modifying linked IDP Portal
- [PORTAL] reload Frontend configuration when removing a related IDP portal to avoid future errors on Haproxy configuration tests

## Added
- [LDAP] [GUI] Don't allow repository removals if still referenced by a Portal
- [Portal] [GUI] Don't allow removals if still referenced by a workflow or another portal
- [OpenID [GUI] Don't allow removals if still referenced by a portal