### PR TITLE
Version 1.2.10

### DIFF
--- a/vulture_os/gui/static/js/darwin_policy_edit.js
+++ b/vulture_os/gui/static/js/darwin_policy_edit.js
@@ -38,6 +38,7 @@ function init_vue(){
       tagRsyslog: "",
       enrichmentTagsRsyslog: "",
       filter: {
+        id: 0,
         filter_type: null,
         enabled: true,
         nb_thread: 5,
@@ -126,6 +127,9 @@ function init_vue(){
             self.policy.buffer_outputs = []
 
             for (let filter of data.filters){
+              if (clone) {
+                filter.id = 0;
+              }
               filter_type = available_filter_types[filter.filter_type]
               if (filter_type) {
                 if (filter_type.name === "content_inspection")
@@ -494,6 +498,7 @@ function init_vue(){
         this.policy.filters.push(data)
 
         this.filter = {
+          id: 0,
           filter_type: null,
           enabled: true,
           nb_thread: 5,
@@ -608,6 +613,7 @@ function init_vue(){
           }
 
           let tmp = {
+            id: tmp_filter.id,
             filter_type: tmp_filter.filter_type,
             enabled: tmp_filter.enabled,
             threshold: parseInt(tmp_filter.threshold, 10),

--- a/vulture_os/services/config/darwin.conf
+++ b/vulture_os/services/config/darwin.conf
@@ -10,11 +10,10 @@
             "cache_size": 0,
             "output": "NONE",
             "next_filter": ""
-        }{% if filters %},{% endif %}
-        {%- set ns = namespace(first=true) %}
+        }
         {%- for darwinfilter in filters %}
         {%- if darwinfilter.filter_type.is_launchable and darwinfilter.enabled -%}
-        {%- if not ns.first %},{% endif %}{% set ns.first = false -%}{
+        ,{
             "name": "{{darwinfilter.name}}",
             "exec_path": "{{darwinfilter.filter_type.exec_path}}",
             "config_file": "{{darwinfilter.conf_path}}",

--- a/vulture_os/services/rsyslogd/config/rsyslog_darwin/ruleset.conf
+++ b/vulture_os/services/rsyslogd/config/rsyslog_darwin/ruleset.conf
@@ -7,7 +7,9 @@
     {% for action in darwin_actions -%}
         {# Set default calls for filter type and techno only if custom ones are not configured (and defaults exist) -#}
         {% if not action.calls and darwin_default_calls and darwin_default_calls[action.filter_type] -%}
-            {% set _ = action.calls.extend(darwin_default_calls[action.filter_type]) -%}
+            {% for call in darwin_default_calls[action.filter_type] -%}
+                {% set _ = action.calls.append({"inputs": call.inputs.copy(), "outputs": call.outputs.copy()}) -%}
+            {% endfor -%}
         {% endif -%}
         {# Set enrichment variables' list -#}
         {% if not action.disable_enrichment and frontend.darwin_mode in ["back", "both"] -%}


### PR DESCRIPTION
## Fixed
- [RSYSLOG] [DARWIN] [CONF] buffer inputs could contain too much entries
- [DARWIN] [CONF] general Darwin configuration was incorrect when no filters were configured
- [DARWIN] avoid recreating filters when editing policies in GUI or on APIs
- [DARWIN] [GUI] Properly copy filters when copying a policy (don't reuse filters from copied one)