### PR TITLE
Beta 1.3.6

### DIFF
--- a/vulture_os/gui/static/js/listener.js
+++ b/vulture_os/gui/static/js/listener.js
@@ -281,7 +281,7 @@ $(function() {
 
   function refresh_input_logs_type(mode, listening_mode, filebeat_listening_mode){
     var first = true;
-    if((mode === "log" && listening_mode !== "api") || (mode === "filebeat" && filebeat_listening_mode !== "api") ){
+    if((mode === "log" && listening_mode !== "api") || (mode === "filebeat") ){
       $('#ruleset-div').show();
       $('#id_node').show();
     }

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -456,7 +456,7 @@ def frontend_edit(request, object_id=None, api=False):
                 changed_data = form.changed_data
 
                 """ If the ruleset has changed, we need to delete the old-named file """
-                if frontend.mode == "log" and "ruleset" in changed_data and old_rsyslog_filename:
+                if frontend.mode in ["log", "filebeat"] and "ruleset" in changed_data and old_rsyslog_filename:
 
                     # API request deletion of rsyslog frontend filename
                     Cluster.api_request('services.rsyslogd.rsyslog.delete_conf', old_rsyslog_filename)

--- a/vulture_os/toolkit/api_parser/cortex_xdr/cortex_xdr.py
+++ b/vulture_os/toolkit/api_parser/cortex_xdr/cortex_xdr.py
@@ -167,6 +167,7 @@ class CortexXDRParser(ApiParser):
                 if len(logs) > 0:
                     # Replace "Z" by "+00:00" for datetime parsing
                     # No need to make_aware, date already contains timezone
-                    setattr(self.frontend, f"cortex_xdr_{kind}_timestamp", datetime.fromtimestamp(logs[-1][KIND_TIME_FIELDS[kind]]/1000, tz=timezone.utc))
+                    # add 1 (ms) to timestamp to avoid getting last alert again
+                    setattr(self.frontend, f"cortex_xdr_{kind}_timestamp", datetime.fromtimestamp((logs[-1][KIND_TIME_FIELDS[kind]]+1)/1000, tz=timezone.utc))
 
         logger.info("CortexXDR parser ending.")


### PR DESCRIPTION
### Fixed
- [LOGAPI] [CORTEX XDR] Prevent getting last log line repeatedly
- [LOGAPI] [REACHFIVE] Properly get most recent date from all logs received
- [FRONTEND] [RSYSLOG CONF] Remove old ruleset file when ruleset is changed in 'filebeat' mode
- [FRONTEND] [GUI] Allow selecting a ruleset when in mode 'filebeat' and type 'Vendor Specific API'