### PR TITLE
Frontend reload asynchronously + new supervision endpoints 

### DIFF
--- a/vulture_os/services/frontend/config/haproxy_frontend.conf
+++ b/vulture_os/services/frontend/config/haproxy_frontend.conf
@@ -94,23 +94,6 @@ cache cache_{{ conf.id }}
     {{ acl }}
     {% endfor %}
 
-    {%- if conf.workflows %}
-    # Workflow ACLs
-    {%- for workflow in conf.workflows %}
-    {%- if workflow.backend.mode == "http" %}
-    acl workflow_{{workflow.id}}_host hdr(host) {{workflow.fqdn}}
-    acl workflow_{{workflow.id}}_host hdr(host) -m beg {{workflow.fqdn}}:
-    acl workflow_{{workflow.id}}_dir path -i -m beg {{ workflow.public_dir }}
-    {% if workflow.authentication %}
-    # Do not make 302 to /?redirect={asked_url}   if
-    acl workflow_{{workflow.id}}_dir_auth path -i -m beg {{ workflow.public_dir }}
-    acl workflow_{{workflow.id}}_dir_auth path -i -m beg /templates/
-    acl workflow_{{workflow.id}}_dir_auth path -i -m beg {{ workflow.public_dir }}{{global_config.public_token}}/
-    {%- endif -%}
-    {%- endif -%}
-    {% endfor %}
-    {%- endif %}
-
     # IDP ACL
     {% for authentication in conf.external_idps %}
     acl idp_{{authentication.id}}_host hdr(host) {{authentication.external_fqdn}}
@@ -124,26 +107,29 @@ cache cache_{{ conf.id }}
     {%- set ns_user_agent = namespace(user_agent=false) -%}
     {%- set ns_defender = namespace(defender=false) -%}
 
-    {%- if conf.workflows -%}
-    {%- for workflow in conf.workflows -%}
-    {%- if workflow.defender_policy -%}
-    filter spoe engine mod_defender config {{workflow.defender_policy.get_spoe_filename()}}
-    {%- set ns_defender.defender = true %}
-    {%- endif %}
-    {%- if workflow.authentication -%}
-    {%- set ns_session.session = true %}
-    {%- endif %}
-    {% endfor %}
-
-    {%- if ns_defender.defender %}
+    {%- if conf.defender_enabled %}
     http-request deny if { var(sess.defender.status) -m int gt 0 }
     {%- endif %}
 
-    {%- if ns_session.session %}
+    {%- if conf.session_enabled %}
     filter spoe engine session config {{ conf.CONF_PATH }}/spoe_session.txt
     {%- endif %}
 
+    {% if conf.workflows %}
     {% for workflow in conf.workflows -%}
+    # Workflow ACL
+    {%- if workflow.backend.mode == "http" %}
+    acl workflow_{{workflow.id}}_host hdr(host) {{workflow.fqdn}}
+    acl workflow_{{workflow.id}}_host hdr(host) -m beg {{workflow.fqdn}}:
+    acl workflow_{{workflow.id}}_dir path -i -m beg {{ workflow.public_dir }}
+    {% if workflow.authentication %}
+    # Do not make 302 to /?redirect={asked_url}   if
+    acl workflow_{{workflow.id}}_dir_auth path -i -m beg {{ workflow.public_dir }}
+    acl workflow_{{workflow.id}}_dir_auth path -i -m beg /templates/
+    acl workflow_{{workflow.id}}_dir_auth path -i -m beg {{ workflow.public_dir }}{{global_config.public_token}}/
+    {%- endif -%}
+    {%- endif -%}
+
     {%- if workflow.access_controls_deny|length -%}
     {% for acl in workflow.access_controls_deny %}
     {% for condition in acl.conditions %}

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -1264,6 +1264,7 @@ class Frontend(models.Model):
                 tmp['access_controls_deny'] = access_controls_deny
                 tmp['access_controls_302'] = access_controls_302
                 tmp['access_controls_301'] = access_controls_301
+
                 workflow_list.append(tmp)
 
         result = {
@@ -1309,7 +1310,10 @@ class Frontend(models.Model):
             'filebeat_module': self.filebeat_module,
             'filebeat_config': self.filebeat_config,
             'filebeat_listening_mode': self.filebeat_listening_mode,
-            'external_idps': self.userauthentication_set.filter(enable_external=True)
+            'external_idps': self.userauthentication_set.filter(enable_external=True),
+            'defender_enabled': self.workflow_set.filter(defender_policy__isnull=False).count() > 0,
+            'session_enabled': self.workflow_set.filter(authentication__isnull=False).count() > 0
+
         }
 
         if self.mode == "impcap":
@@ -1351,38 +1355,38 @@ class Frontend(models.Model):
         # If there was an exception, raise a more general exception with the message and the traceback
         raise exception
 
-    def test_conf(self):
+    def test_conf(self, node_name):
         """ Write the configuration attribute on disk, in test directory, as {id}.conf.new
             And test the conf with 'haproxy -c'
         :return     True or raise
         """
         test_filename = self.get_test_filename()
-        for node_name, conf in self.configuration.items():
-            if not conf:
-                return
-            test_conf = conf.replace("frontend {}".format(self.name),
-                                     "frontend test_{}".format(self.id or "test")) \
-                            .replace("listen {}".format(self.name),
-                                     "listen test_{}".format(self.id or "test"))
-            if node_name != Cluster.get_current_node().name:
-                try:
-                    global_config = Cluster().get_global_config()
-                    cluster_api_key = global_config.cluster_api_key
-                    infos = post("https://{}:8000/api/services/frontend/test_conf/".format(node_name),
-                                 headers={'cluster-api-key': cluster_api_key},
-                                 data={'conf': test_conf, 'filename': test_filename, 'disabled': not self.enabled},
-                                 verify=False, timeout=9).json()
-                except Exception as e:
-                    logger.error(e)
-                    raise ServiceTestConfigError("on node '{}'\n Request failure.".format(node_name), "haproxy")
-                if not infos.get('status'):
-                    raise ServiceTestConfigError("on node '{}'\n{}".format(node_name, infos.get('error')), "haproxy",
-                                                 traceback=infos.get('error_details'))
-            else:
-                # Replace name of frontend to prevent duplicate frontend while testing conf
-                test_haproxy_conf(test_filename,
-                                  test_conf,
-                                  disabled=(not self.enabled))
+        conf = self.configuration.get(node_name)
+        if not conf:
+            return
+        test_conf = conf.replace("frontend {}".format(self.name),
+                                 "frontend test_{}".format(self.id or "test")) \
+                        .replace("listen {}".format(self.name),
+                                 "listen test_{}".format(self.id or "test"))
+        if node_name != Cluster.get_current_node().name:
+            try:
+                global_config = Cluster().get_global_config()
+                cluster_api_key = global_config.cluster_api_key
+                infos = post("https://{}:8000/api/services/frontend/test_conf/".format(node_name),
+                             headers={'cluster-api-key': cluster_api_key},
+                             data={'conf': test_conf, 'filename': test_filename, 'disabled': not self.enabled},
+                             verify=False, timeout=9).json()
+            except Exception as e:
+                logger.error(e)
+                raise ServiceTestConfigError("on node '{}'\n Request failure.".format(node_name), "haproxy")
+            if not infos.get('status'):
+                raise ServiceTestConfigError("on node '{}'\n{}".format(node_name, infos.get('error')), "haproxy",
+                                             traceback=infos.get('error_details'))
+        else:
+            # Replace name of frontend to prevent duplicate frontend while testing conf
+            test_haproxy_conf(test_filename,
+                              test_conf,
+                              disabled=(not self.enabled))
 
     def get_base_filename(self):
         """ Return the base filename (without path) """
@@ -1650,14 +1654,9 @@ class Frontend(models.Model):
          """
         nodes = set()
         for node in self.get_nodes():
-            # Generate frontend conf with no error_template
-            self.configuration[node.name] = self.generate_conf(node=node)
-            # And write conf on disk
-            self.save_conf(node)
+            node.api_request("services.haproxy.haproxy.build_conf", self.id)
             # Add node to nodes, it's a set (unicity implicitly handled)
             nodes.add(node)
-        # Save the object in database to save the configuration attribute
-        self.save()
         return nodes
 
     def enable(self):

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -217,7 +217,7 @@ def frontend_edit(request, object_id=None, api=False):
         validate = request.JSON.get('validate', True)
         form = FrontendForm(request.JSON or {}, instance=frontend, error_class=DivErrorList)
     else:
-        validate = request.POST.get('validate', True)
+        validate = request.POST.get('validate', True) not in (False, "false", "False")
         form = FrontendForm(request.POST or empty, instance=frontend, error_class=DivErrorList)
 
     def render_form(front, **kwargs):

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -214,8 +214,10 @@ def frontend_edit(request, object_id=None, api=False):
     """ Create form with object if exists, and request.POST (or JSON) if exists """
     empty = {} if api else None
     if hasattr(request, "JSON") and api:
+        validate = request.JSON.get('validate', True)
         form = FrontendForm(request.JSON or {}, instance=frontend, error_class=DivErrorList)
     else:
+        validate = request.POST.get('validate', True)
         form = FrontendForm(request.POST or empty, instance=frontend, error_class=DivErrorList)
 
     def render_form(front, **kwargs):
@@ -431,16 +433,14 @@ def frontend_edit(request, object_id=None, api=False):
         try:
             """ For each node, the conf differs if listener chosen """
             """ Generate the conf """
-            logger.debug("Generating conf of frontend '{}'".format(frontend.name))
-            for node, listeners in node_listeners.items():
-                # HAProxy conf does not use reputationctx_list, Rsyslog conf does
-                frontend.configuration[node.name] = frontend.generate_conf(listener_list=listeners,
+            if validate:
+                logger.debug("Generating conf of frontend '{}'".format(frontend.name))
+                for node, listeners in node_listeners.items():
+                    # HAProxy conf does not use reputationctx_list, Rsyslog conf does
+                    frontend.configuration[node.name] = frontend.generate_conf(listener_list=listeners,
                                                                            header_list=header_objs)
-
-            """ Save the conf on disk, and test-it with haproxy -c """
-            logger.debug("Writing/Testing conf of frontend '{}'".format(frontend.name))
-            frontend.test_conf()
-
+                    frontend.test_conf(node.name)
+                    logger.info(f"FRONTEND::Edit: Configuration test ok on node {node.name}")
         except ServiceError as e:
             logger.exception(e)
             return render_form(frontend, save_error=[str(e), e.traceback])
@@ -574,15 +574,11 @@ def frontend_edit(request, object_id=None, api=False):
                                                          arg_field=reputationctx.arg_field,
                                                          dst_field=reputationctx.dst_field)
 
-            # Re-generate config AFTER save, to get ID
-            for node, listeners in node_listeners.items():
-                frontend.configuration[node.name] = frontend.generate_conf(listener_list=listeners)
-
             for node in node_listeners.keys():
 
                 """ asynchronous API request to save conf on node """
                 # Save conf first, to raise if there is an error
-                frontend.save_conf(node)
+                node.api_request("services.haproxy.haproxy.build_conf", frontend.id)
                 logger.debug("Write conf of frontend '{}' asked on node '{}'".format(frontend.name, node.name))
 
                 """ We need to configure Rsyslog, it will check if conf has changed & restart service if needed """

--- a/vulture_os/services/haproxy/haproxy.py
+++ b/vulture_os/services/haproxy/haproxy.py
@@ -292,9 +292,8 @@ def delete_conf(node_logger, filename):
 
 
 def build_conf(node_logger, frontend_id):
-    """ Generate conf of rsyslog inputs, based on all frontends LOG
-    ruleset of frontend
-    outputs of all frontends
+    """ Generate conf of haproxy frontend
+    with it's ID
     :param node_logger: Logger sent to all API requests
     :param frontend_id: The name of the frontend in conf file
     :return:
@@ -311,6 +310,7 @@ def build_conf(node_logger, frontend_id):
         tmp = frontend.generate_conf()
         if frontend.configuration[node.name] != tmp:
             frontend.configuration[node.name] = tmp
+            frontend.save()
             reload = True
         """ And write-it """
 
@@ -321,7 +321,7 @@ def build_conf(node_logger, frontend_id):
         raise VultureSystemError("Frontend with id {} not found, failed to generate conf.".format(frontend_id),
                                  "build HAProxy conf", traceback=" ")
 
-    """ Generate inputs configuration """
+    """ Restart service if needed (conf has changed) """
     service = HaproxyService()
     """ If frontend was given we cannot check if its conf has changed to restart service
      and if reload_conf is True, conf has changed so restart service

--- a/vulture_os/services/haproxy/haproxy.py
+++ b/vulture_os/services/haproxy/haproxy.py
@@ -308,7 +308,7 @@ def build_conf(node_logger, frontend_id):
         frontend = models.Frontend.objects.get(pk=frontend_id)
         """ Generate ruleset conf of asked frontend """
         tmp = frontend.generate_conf()
-        if frontend.configuration[node.name] != tmp:
+        if frontend.configuration.get(node.name) != tmp:
             frontend.configuration[node.name] = tmp
             frontend.save()
             reload = True

--- a/vulture_os/system/cluster/api.py
+++ b/vulture_os/system/cluster/api.py
@@ -38,6 +38,7 @@ from system.cluster.models import Node, MessageQueue
 from system.cluster.views import COMMAND_LIST, cluster_edit
 from system.cluster.models import Cluster
 from toolkit.mongodb.mongo_base import MongoBase
+from services.frontend.models import Frontend
 
 # Required exceptions imports
 
@@ -203,6 +204,74 @@ def get_message_queues(request):
         return JsonResponse({
             'status': True,
             'data': res
+        })
+
+    except Exception as e:
+        logger.critical(e, exc_info=1)
+        if settings.DEV_MODE:
+            raise
+
+        return JsonResponse({
+            'status': False,
+            'data': _('An error has occurred')
+        }, 500)
+
+
+@api_need_key('cluster_api_key')
+@require_http_methods(['GET'])
+def get_cluster_status(request):
+    try:
+        params = {}
+        node_name = request.GET.get('node')
+        node = None
+        if node_name:
+            try:
+                node = Node.objects.get(name=node_name)
+                params['node'] = node
+            except Node.DoesNotExist:
+                return JsonResponse({
+                    'status': False,
+                    'data': _("Invalid parameter 'node'")},
+                    status=404
+                )
+
+        pending_tasks = MessageQueue.objects.filter(**params, status__in=["new", "running"]).count()
+        failed_tasks = MessageQueue.objects.filter(**params, status="failure").count()
+
+        result = True
+        frontends_status = []
+        for f in Frontend.objects.filter(enabled=True):
+            if node:
+                if node not in f.get_nodes():
+                    continue
+                f_status = f.status.get(node.name, "UNKNOWN")
+                if f_status != "OPEN":
+                    logger.info(f_status)
+                    result = False
+            else:
+                # No need to set status=False if it already is
+                if result:
+                    # Check on each node is status is UP
+                    for f_node, f_stat in f.status.items():
+                        if f_stat != "OPEN":
+                            logger.info(f_stat)
+                            result = False
+                f_status = f.status
+
+            frontends_status.append({f.name: f_status})
+
+        if result and (pending_tasks > 0 or failed_tasks > 0):
+            result = False
+
+        return JsonResponse({
+            'status': result,
+            'data': {
+                'tasks': {
+                    'pendings': pending_tasks,
+                    'failed': failed_tasks
+                },
+                'frontends': frontends_status
+            }
         })
 
     except Exception as e:

--- a/vulture_os/system/cluster/api.py
+++ b/vulture_os/system/cluster/api.py
@@ -246,7 +246,6 @@ def get_cluster_status(request):
                     continue
                 f_status = f.status.get(node.name, "UNKNOWN")
                 if f_status != "OPEN":
-                    logger.info(f_status)
                     result = False
             else:
                 # No need to set status=False if it already is
@@ -254,7 +253,6 @@ def get_cluster_status(request):
                     # Check on each node is status is UP
                     for f_node, f_stat in f.status.items():
                         if f_stat != "OPEN":
-                            logger.info(f_stat)
                             result = False
                 f_status = f.status
 
@@ -267,7 +265,7 @@ def get_cluster_status(request):
             'status': result,
             'data': {
                 'tasks': {
-                    'pendings': pending_tasks,
+                    'pending': pending_tasks,
                     'failed': failed_tasks
                 },
                 'frontends': frontends_status

--- a/vulture_os/system/cluster/api.py
+++ b/vulture_os/system/cluster/api.py
@@ -231,7 +231,7 @@ def get_cluster_status(request):
             except Node.DoesNotExist:
                 return JsonResponse({
                     'status': False,
-                    'data': _("Invalid parameter 'node'")},
+                    'data': _(f"node with name {node_name} does not exist")},
                     status=404
                 )
 

--- a/vulture_os/system/cluster/api.py
+++ b/vulture_os/system/cluster/api.py
@@ -194,7 +194,7 @@ def get_message_queues(request):
         except:
             return JsonResponse({
                 'status': False,
-                'data': _("Invalid parameter 'limit'")
+                'data': _("Invalid value for parameter 'limit'")
             }, status=400)
 
         tasks = MessageQueue.objects.filter(**params).order_by('modified')[:limit]

--- a/vulture_os/system/cluster/api.py
+++ b/vulture_os/system/cluster/api.py
@@ -188,7 +188,6 @@ def get_message_queues(request):
         if node:
             params['node__name'] = node
 
-        tasks = MessageQueue.objects.filter(**params).order_by('modified')
         limit = request.GET.get('limit', "100")
         try:
             limit = int(limit)
@@ -197,7 +196,8 @@ def get_message_queues(request):
                 'status': False,
                 'data': _("Invalid parameter 'limit'")
             }, status=400)
-        tasks = tasks[:limit]
+
+        tasks = MessageQueue.objects.filter(**params).order_by('modified')[:limit]
 
         res = [m.to_template() for m in tasks]
 

--- a/vulture_os/system/cluster/models.py
+++ b/vulture_os/system/cluster/models.py
@@ -435,12 +435,13 @@ class Node(models.Model):
 
                 message.result = my_function(*args)
                 message.status = 'done'
-            except ServiceExit:
+            except ServiceExit as e:
                 """ Service stop asked """
-                raise
+                raise e
             except KeyError as e:
                 logger.exception(e)
                 message.result = "KeyError {}".format(str(e))
+                message.status = 'failure'
             except Exception as e:
                 logger.exception(e)
                 logger.error("Cluster::process_messages: {}".format(str(e)))

--- a/vulture_os/system/cluster/urls.py
+++ b/vulture_os/system/cluster/urls.py
@@ -65,6 +65,10 @@ urlpatterns = [
          api.get_message_queues,
          name="system.cluster.tasks"),
 
+    path('api/v1/system/cluster/status/',
+         api.get_cluster_status,
+         name="system.cluster.status"),
+
     path('api/v1/system/node/', api.NodeAPIv1.as_view(), name="system.node.api"),
 
     path('api/v1/system/node/<int:object_id>/', api.NodeAPIv1.as_view(), name="system.node.api"),

--- a/vulture_os/system/cluster/urls.py
+++ b/vulture_os/system/cluster/urls.py
@@ -61,6 +61,10 @@ urlpatterns = [
          api.secret_key,
          name="system.cluster.key"),
 
+    path('api/v1/system/cluster/tasks/',
+         api.get_message_queues,
+         name="system.cluster.tasks"),
+
     path('api/v1/system/node/', api.NodeAPIv1.as_view(), name="system.node.api"),
 
     path('api/v1/system/node/<int:object_id>/', api.NodeAPIv1.as_view(), name="system.node.api"),


### PR DESCRIPTION
### Added
 - [FRONTEND]
   -  Add 'validate' boolean parameter to disable config testing
   - Improve performances by reloading frontend config asynchronously
   - Refactor jinja template haproxy_frontend for better performances
 - [API][CLUSTER] Add supervision api endpoint to get tasks
 - [API][CLUSTER] Add supervision api endpoint to get cluster/node status (pending tasks, frontend statuses)

### Fixed
 - [VULTURED] Update status of task if an error occured (status was let 'running' forever)
