### PR TITLE
Release 1.7.0

### DIFF
--- a/home/jails.apache/.zfs-source/usr/local/etc/gunicorn.d/portal.conf.py
+++ b/home/jails.apache/.zfs-source/usr/local/etc/gunicorn.d/portal.conf.py
@@ -1,0 +1,11 @@
+# Gunicorn configuration file for portal
+bind="127.0.0.7:9000"
+accesslog="/var/log/vulture/os/gunicorn-access.log"
+errorlog="/var/log/vulture/os/gunicorn-error.log"
+worker_connections=1000
+workers=50
+keyfile="/var/db/pki/node.key"
+certfile="/var/db/pki/node.cert"
+ca_certs="/var/db/pki/ca.pem"
+ciphers="ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-CAMELLIA256-SHA384:ECDHE-RSA-CAMELLIA256-SHA384:ECDHE-ECDSA-CAMELLIA128-SHA256:ECDHE-RSA-CAMELLIA128-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:CAMELLIA128-SHA256"
+access_log_format='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'

--- a/home/jails.apache/.zfs-source/usr/local/etc/rc.d/gunicorn
+++ b/home/jails.apache/.zfs-source/usr/local/etc/rc.d/gunicorn
@@ -26,9 +26,10 @@ command="/home/vlt-os/env/bin/python3.8"
 : ${gunicorn_enable:="NO"}
 : ${gunicorn_pid_file:="/var/run/gunicorn.pid"}
 : ${gunicorn_conf_file:="/usr/local/etc/gunicorn.d/portal.conf.py"}
+: ${gunicorn_workers:="5"}
 load_rc_config $name
 
-command_args="/home/vlt-os/env/bin/gunicorn portal.wsgi -D -c ${gunicorn_conf_file} -p ${gunicorn_pid_file}"
+command_args="/home/vlt-os/env/bin/gunicorn portal.wsgi -D -w ${gunicorn_workers} -c ${gunicorn_conf_file} -p ${gunicorn_pid_file}"
 # Define this method to use /etc/rc.subr routine
 pidfile="$gunicorn_pid_file"
 extra_commands="reload"

--- a/home/jails.apache/.zfs-source/usr/local/etc/rc.d/gunicorn
+++ b/home/jails.apache/.zfs-source/usr/local/etc/rc.d/gunicorn
@@ -16,20 +16,19 @@
 #               Set to the full path of the pid file
 # gunicorn_conf_file (str):     default: /usr/local/etc/gunicorn.d/portal.conf.py
 #               Set to the full path of the config file
-
 . /etc/rc.subr
-
-: ${gunicorn_enable:="NO"}
-: ${gunicorn_pid_file:="/var/run/gunicorn.pid"}
-: ${gunicorn_conf_file:="/usr/local/etc/gunicorn.d/portal.conf.py"}
-
 
 name="gunicorn"
 rcvar=gunicorn_enable
 gunicorn_group="vlt-web"
 command="/home/vlt-os/env/bin/python3.8"
-command_args="/home/vlt-os/env/bin/gunicorn portal.wsgi -D -c ${gunicorn_conf_file} -p ${gunicorn_pid_file}"
 
+: ${gunicorn_enable:="NO"}
+: ${gunicorn_pid_file:="/var/run/gunicorn.pid"}
+: ${gunicorn_conf_file:="/usr/local/etc/gunicorn.d/portal.conf.py"}
+load_rc_config $name
+
+command_args="/home/vlt-os/env/bin/gunicorn portal.wsgi -D -c ${gunicorn_conf_file} -p ${gunicorn_pid_file}"
 # Define this method to use /etc/rc.subr routine
 pidfile="$gunicorn_pid_file"
 extra_commands="reload"
@@ -46,3 +45,4 @@ gunicorn_prestart()
 }
 
 run_rc_command "$1"
+

--- a/home/jails.apache/.zfs-source/usr/local/etc/rc.d/gunicorn
+++ b/home/jails.apache/.zfs-source/usr/local/etc/rc.d/gunicorn
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# VultureOS: Service script to manage gunicorn for portal
+#
+
+# PROVIDE: gunicorn
+# REQUIRE: LOGIN cleanvar sshd
+# KEYWORD: shutdown
+
+#
+# Add the following lines to /etc/rc.conf to enable gunicorn:
+#
+# gunicorn_enable (bool):    default: "NO"
+#               Set to "YES" to enable gunicorn
+# gunicorn_pid_file (str):    default: /var/run/gunicorn.pid
+#               Set to the full path of the pid file
+# gunicorn_conf_file (str):     default: /usr/local/etc/gunicorn.d/portal.conf.py
+#               Set to the full path of the config file
+
+. /etc/rc.subr
+
+: ${gunicorn_enable:="NO"}
+: ${gunicorn_pid_file:="/var/run/gunicorn.pid"}
+: ${gunicorn_conf_file:="/usr/local/etc/gunicorn.d/portal.conf.py"}
+
+
+name="gunicorn"
+rcvar=gunicorn_enable
+gunicorn_group="vlt-web"
+command="/home/vlt-os/env/bin/python3.8"
+command_args="/home/vlt-os/env/bin/gunicorn portal.wsgi -D -c ${gunicorn_conf_file} -p ${gunicorn_pid_file}"
+
+# Define this method to use /etc/rc.subr routine
+pidfile="$gunicorn_pid_file"
+extra_commands="reload"
+sig_reload="HUP"
+# Needed to CD into project base
+start_precmd="gunicorn_prestart"
+
+
+# Define pre-start function to CD into project directory (otherwise gunicorn can't locate portal.wsgi file)
+gunicorn_prestart()
+{
+    cd /home/vlt-os/vulture_os
+    return 0
+}
+
+run_rc_command "$1"

--- a/vulture_os/services/frontend/config/haproxy_frontend.conf
+++ b/vulture_os/services/frontend/config/haproxy_frontend.conf
@@ -180,7 +180,7 @@ cache cache_{{ conf.id }}
     # Handle self service
     http-request set-var(req.use_portal) str("{{workflow.id}}") if workflow_{{workflow.id}}_host { path -i -m beg {{workflow.public_dir}}{{global_config.public_token}}/self }
     http-request replace-path {{workflow.public_dir}}{{global_config.public_token}}/(.*) /\1 if workflow_{{workflow.id}}_host { path -i -m beg {{workflow.public_dir}}{{global_config.public_token}}/self }
-    use_backend portal_{{workflow.id}} if { var(req.use_portal) {{workflow.id}} }
+    use_backend portal_{{workflow.id}} if { var(req.use_portal) -m str "{{workflow.id}}" }
 
     # Session verification
     # In case of SPOE error : Return Gateway-Timeout

--- a/vulture_os/toolkit/updates/v1.7.0/0_migrate_portal_gunicorn.sh
+++ b/vulture_os/toolkit/updates/v1.7.0/0_migrate_portal_gunicorn.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "[+] Stopping apache into portal jail"
+/usr/sbin/jexec portal /usr/sbin/service apache24 stop
+echo "[*] done"
+
+/bin/rm /zroot/portal/etc/rc.conf.d/apache24
+
+/bin/echo 'gunicorn_enable="YES"' > /zroot/portal/etc/rc.conf.d/gunicorn

--- a/vulture_os/toolkit/updates/v1.7.0/1_reload_frontends_conf.py
+++ b/vulture_os/toolkit/updates/v1.7.0/1_reload_frontends_conf.py
@@ -1,0 +1,63 @@
+#!/home/vlt-os/env/bin/python
+
+"""This file is part of Vulture 4.
+
+Vulture 4 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vulture 4 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vulture 4.  If not, see http://www.gnu.org/licenses/.
+"""
+__author__ = "Kevin Guillemot"
+__credits__ = []
+__license__ = "GPLv3"
+__version__ = "4.0.0"
+__maintainer__ = "Vulture Project"
+__email__ = "contact@vultureproject.org"
+__doc__ = "Reload HTTP frontends configuration due to jinja template update"
+
+import sys
+import os
+
+if not os.path.exists("/home/vlt-os/vulture_os/.node_ok"):
+    sys.exit(0)
+
+# Django setup part
+sys.path.append('/home/vlt-os/vulture_os')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'vulture_os.settings')
+
+import django
+from django.conf import settings
+django.setup()
+
+from system.cluster.models import Cluster, Node
+from services.frontend.models import Frontend
+from authentication.user_portal.models import UserAuthentication
+
+
+if __name__ == "__main__":
+
+    node = Cluster.get_current_node()
+    if not node:
+        print("Current node not found. Maybe the cluster has not been initiated yet.")
+    else:
+        try:
+            # If authentication, reload frontend and portal Haproxy configs
+            for frontend in Frontend.objects.filter(mode="http"):
+                frontend.reload_conf()
+                print("Frontend {} conf reload asked".format(frontend))
+
+            node.api_request("services.haproxy.haproxy.restart_service")
+
+        except Exception as e:
+            print("Failed to update authentication related configurations: {}".format(e))
+            print("Please relaunch this script after solving the issue.")
+
+        print("Done.")


### PR DESCRIPTION
### Fixed
 - [HAProxy][Frontend] Fix acl syntax according to last haproxy version

### Changed
 - [PORTAL] Use **[gunicorn](https://docs.gunicorn.org/en/stable/)** instead of **[apache wsgi](https://pypi.org/project/mod-wsgi/)** to host portal engine
