### PR TITLE
GUNICORN::FIXED:: gunicorn did not listen on IPv6 jail address

### DIFF
--- a/home/jails.apache/.zfs-source/usr/local/etc/gunicorn.d/portal.conf.py
+++ b/home/jails.apache/.zfs-source/usr/local/etc/gunicorn.d/portal.conf.py
@@ -1,5 +1,5 @@
 # Gunicorn configuration file for portal
-bind="127.0.0.7:9000"
+bind=["127.0.0.7:9000","[fd00::207]:9000"]
 accesslog="/var/log/vulture/os/gunicorn-access.log"
 errorlog="/var/log/vulture/os/gunicorn-error.log"
 worker_connections=1000


### PR DESCRIPTION
### FIXED
- [PORTAL] [GUNICORN CONF] service didn't listen on jail's IPv6 address (no connection from IPv6 networks)