### PR TITLE
Portal fixes

### DIFF
--- a/vulture_os/authentication/idp/api.py
+++ b/vulture_os/authentication/idp/api.py
@@ -236,7 +236,7 @@ class IDPApiUserView(View):
                                  user_mail,
                                  user,
                                  repo_id=repo_id,
-                                 expire=3600):
+                                 expire=72 * 3600):
                     logger.error(f"Failed to send reset password email to '{user_mail}'")
                     return JsonResponse({'status': False,
                                          'error': _("Fail to send user's reset password email")}, status=500)

--- a/vulture_os/portal/system/authentications.py
+++ b/vulture_os/portal/system/authentications.py
@@ -452,7 +452,7 @@ class DOUBLEAuthentication(Authentication):
 
     def create_authentication(self):
         if self.resend or not self.redis_portal_session.get_otp_key():
-            """ If the user ask for resend otp key or if the otp key has not yet been sent """
+            """ If the user ask to resend otp key or if the otp key has not yet been sent """
             otp_repo = self.workflow.authentication.otp_repository
             user_infos = self.redis_portal_session.get_user_infos(self.backend_id)
             user_phone = user_infos.get('user_phone', None)
@@ -493,6 +493,8 @@ class DOUBLEAuthentication(Authentication):
                 raise OTPError("Error while sending secret key <br> <b> Contact your administrator </b>")
 
             self.redis_portal_session.set_otp_info(otp_info)
+            # Ensure session is valid for at least 5 minutes
+            self.redis_portal_session.set_ttl(300)
             logger.debug("DB-AUTH::create_authentication: OTP key successfully written in Redis session")
 
         elif self.workflow.authentication.otp_repository.otp_type == "totp":

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -71,12 +71,15 @@ class REDISSession(object):
     def __getitem__(self, key):
         return self.keys.get(key)
 
+    def set_ttl(self, ttl):
+        if self.handler.ttl(self.key) < ttl:
+            return self.handler.expire(self.key, ttl)
+        return True
+
     def write_in_redis(self, timeout):
         # Do NOT write user_infos in Redis, it has already be done  in set_user_infos
         if self.handler.hmset(self.key, {k:v for k,v in self.keys.items() if not k.startswith("user_infos_") and v is not None}):
-            if self.handler.ttl(self.key) < timeout:
-                return self.handler.expire(self.key, timeout)
-            return True
+            return self.set_ttl(timeout)
         else:
             return False
 

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -506,6 +506,7 @@ class REDISOauth2Session(REDISSession):
                 self.keys['scope'] = {}
             if not self.keys.get('token_ttl'):
                 self.keys['token_ttl'] = timeout
+                self.keys['iat'] = int(time.time())
                 self.keys['exp'] = int(time.time()) + timeout
             if not self.keys.get('repo'):
                 self.keys['repo'] = repo_id

--- a/vulture_os/portal/system/self_actions.py
+++ b/vulture_os/portal/system/self_actions.py
@@ -311,6 +311,11 @@ class SELFServiceChange(SELFService):
 
         return old_password
 
+
+    def action_ok_message(self):
+        return "Password successfully changed"
+
+
     # Change password
     def perform_action(self, request, old_password):
 
@@ -365,7 +370,8 @@ class SELFServiceChange(SELFService):
             # Delete key in Redis
             self.redis_base.delete('password_reset_' + rdm)
 
-        return "Password successfully changed"
+        return self.action_ok_message()
+
 
     def ask_credentials_response(self, request, action, error_msg, **kwargs):
         rdm = request.GET.get(RESET_PASSWORD_NAME, None) or request.POST.get(RESET_PASSWORD_NAME, None)

--- a/vulture_os/portal/views/logon.py
+++ b/vulture_os/portal/views/logon.py
@@ -257,7 +257,7 @@ def openid_callback(request, workflow_id, repo_id):
             'access_token': oauth2_token,
             'token_type': "Bearer",
             'scope': ["openid"],
-            'created_at': session['iat'],
+            'iat': session['iat'],
             'exp': session['exp'],
         })
 
@@ -369,7 +369,7 @@ def openid_token(request, portal_id):
             'access_token': session['access_token'],
             'token_type': "Bearer",
             'scope': ["openid"],
-            'created_at': session['iat'],
+            'iat': session['iat'],
             'exp': session['exp'],
         })
     except RedisError as e:
@@ -411,6 +411,7 @@ def openid_userinfo(request, portal_id=None, workflow_id=None):
         assert session['scope'], "Session does not contain any scope"
         # Add internal Oauth2 attributes
         session['scope'].update({'exp': session['exp']})
+        session['scope'].update({'iat': session['iat']})
         return JsonResponse(session['scope'])
     except AssertionError as e:
         logger.info(e)

--- a/vulture_os/toolkit/auth/ldap_client.py
+++ b/vulture_os/toolkit/auth/ldap_client.py
@@ -675,13 +675,22 @@ class LDAPClient(BaseAuth):
         for key, val in user_attrs.items():
             # decode all bytes entries
             if isinstance(val, bytes):
-                val = val.decode('utf-8')
+                try:
+                    val = val.decode('utf-8')
+                except UnicodeDecodeError:
+                    logger.warning(f"ldap_client::_format_user_results:: ignoring key {key} -> cannot decode")
+                    continue
             if isinstance(val, list):
                 for subval in val:
                     if isinstance(subval, bytes):
-                        i = val.index(subval)
-                        val.pop(i)
-                        val.insert(i, subval.decode('utf-8'))
+                        try:
+                            i = val.index(subval)
+                            val.pop(i)
+                            val.insert(i, subval.decode('utf-8'))
+                        except UnicodeDecodeError:
+                            logger.warning(f"ldap_client::_format_user_results:: ignoring value in key {key} -> cannot decode")
+                            continue
+
             if key == "userPassword":
                 continue
             elif key == self.user_groups_attr:


### PR DESCRIPTION
### Added
- [PORTAL] ensure the session stays valid for at least 5 minutes when requesting double-authentication on a portal

### Changed
- [IDP] set reset password URL validity to 72 hours

### Fixed
- [PORTAL] correctly set 'iat' field in token
- [SELF_SERVICE] avoid errors during password change when user does not exist