### PR TITLE
FIX: properly acquire data lock during date updates in multi-threaded api akamai log parser

### DIFF
--- a/vulture_os/toolkit/api_parser/akamai/akamai.py
+++ b/vulture_os/toolkit/api_parser/akamai/akamai.py
@@ -153,8 +153,8 @@ def akamai_parse(akamai):
         queue_write.put(tmp)
 
         # Update the last log time
-        if timestamp > akamai.last_log_time:
-            with data_lock:
+        with data_lock:
+            if timestamp > akamai.last_log_time:
                 akamai.last_log_time = timestamp
 
 


### PR DESCRIPTION
### Fixed
- [API_PARSER][AKAMAI] Properly acquire data_lock during internal last_log_time updates