### PR TITLE
Hotfix:: Validate portal session's format and presence in cache, or create a new value

### DIFF
--- a/vulture_os/toolkit/system/hashes.py
+++ b/vulture_os/toolkit/system/hashes.py
@@ -25,7 +25,10 @@ __doc__ = 'System Utils for Hashes'
 
 from hashlib import sha3_256, sha1
 from os import urandom
+from string import hexdigits
 
+def validate_digest(digest: str) -> bool:
+    return len(digest) == 64 and all(character in hexdigits for character in digest)
 
 def random_sha256():
     return sha3_256(urandom(64)).hexdigest()


### PR DESCRIPTION
### Fixed
- [PORTAL] Create a new portal session value from safe generator if value taken from client cookies is not formatted correctly or is not present in current cache

### Added
- [UTILS] [ HASHES] validation function for hash digest's format (length and characters used)