### PR TITLE
FIX::Retesting already configured OpenID 

### DIFF
--- a/vulture_os/authentication/openid/form.py
+++ b/vulture_os/authentication/openid/form.py
@@ -54,7 +54,7 @@ class OpenIDRepositoryForm(ModelForm):
             'provider': Select(choices=PROVIDERS_TYPE, attrs={'class': 'form-control select2'}),
             'provider_url': TextInput(attrs={'class': 'form-control'}),
             'client_id': TextInput(attrs={'class': 'form-control'}),
-            'client_secret': TextInput(attrs={'class': 'form-control'}),
+            'client_secret': TextInput(attrs={'class': 'form-control','autocomplete': 'off'}),
             'scopes': TextInput(attrs={'class': 'form-control', 'data-role': "tagsinput"}),
             'use_proxy': CheckboxInput(attrs={"class": " js-switch"}),
             'verify_certificate': CheckboxInput(attrs={"class": " js-switch"}),

--- a/vulture_os/authentication/openid/models.py
+++ b/vulture_os/authentication/openid/models.py
@@ -224,29 +224,30 @@ class OpenIDRepository(BaseRepository):
         else:
             raise NotImplemented("OTP client type not implemented yet")
 
-    def retrieve_config(self, test=False, force=True):
+    @staticmethod
+    def retrieve_config(provider_url, use_proxy=True, verify_certificate=True ):
+        logger.info(get_proxy() if use_proxy else None)
+        r = requests.get("{}/.well-known/openid-configuration".format(provider_url),
+                            proxies=get_proxy() if use_proxy else None,
+                            verify=verify_certificate, timeout=10)
+        r.raise_for_status()
+        config = r.json()
+        logger.info(config)
+        return config
+    
+    def openid_save(self, force=True):
         # TODO : Handle CA_BUNDLE
         # If loaded data is too old, reload it again
         refresh_time = timezone.now() - timedelta(hours=CONFIG_RELOAD_INTERVAL)
-        if (self.last_config_time is None or self.last_config_time < refresh_time)\
-                or test:
-            logger.info(get_proxy() if self.use_proxy else None)
-            r = requests.get("{}/.well-known/openid-configuration".format(self.provider_url),
-                             proxies=get_proxy() if self.use_proxy else None,
-                             verify=self.verify_certificate, timeout=10)
-            r.raise_for_status()
-            config = r.json()
-            logger.info(config)
+        if (self.last_config_time is None or self.last_config_time < refresh_time):
+            config = OpenIDRepository.retrieve_config(self.provider_url, self.use_proxy, self.verify_certificate)
             self.issuer = config['issuer']
             self.authorization_endpoint = config['authorization_endpoint']
             self.token_endpoint = config['token_endpoint']
             self.userinfo_endpoint = config['userinfo_endpoint']
             self.end_session_endpoint = config.get('end_session_endpoint') or config['revocation_endpoint']
             self.last_config_time = timezone.now()
-            if not test:
-                self.save()
-            else:
-                return config
+            self.save()
 
     def get_oauth2_session(self, redirect_uri):
         session = OAuth2Session(self.client_id, redirect_uri=redirect_uri, scope=self.scopes)
@@ -261,17 +262,17 @@ class OpenIDRepository(BaseRepository):
         :param  redirect_uri parameter in authorization_url
         :return tuple authorization_url, state
         """
-        self.retrieve_config()
+        self.openid_save()
         return oauth2_session.authorization_url(self.authorization_endpoint)
 
     def fetch_token(self, oauth2_session, code):
-        self.retrieve_config()
+        self.openid_save()
         return oauth2_session.fetch_token(self.token_endpoint,
                                           code=code,
                                           client_secret=self.client_secret)
 
     def get_userinfo(self, oauth2_session):
-        self.retrieve_config()
+        self.openid_save()
         response = oauth2_session.get(self.userinfo_endpoint, verify=self.verify_certificate)
         response.raise_for_status()
         result = response.json()

--- a/vulture_os/authentication/openid/views.py
+++ b/vulture_os/authentication/openid/views.py
@@ -27,7 +27,6 @@ __doc__ = 'OpenID Repository views'
 from django.conf import settings
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
-
 # Django project imports
 from gui.forms.form_utils import DivErrorList
 
@@ -103,19 +102,20 @@ def edit(request, object_id=None, api=False):
 
 
 def test_provider(request):
-    provider = OpenIDRepository.objects.filter(provider=request.POST.get('provider'), client_id=request.POST.get('client_id'), client_secret=request.POST.get('client_secret')).first()
+    errors = {}
+    if not request.POST.get('provider_url'):
+        errors['provider_url'] = ['This field is required.']      
+    if not request.POST.get('client_id'):
+        errors['client_id'] = ['This field is required.']  
+    if not request.POST.get('client_secret'):
+        errors['client_secret'] = ['This field is required.']  
 
-    if not provider:   
-        form = OpenIDRepositoryForm(request.POST)
-
-        if not form.is_valid():
-            return JsonResponse({'status': False,
-                                'form_errors': form.errors})
-
-        provider = form.save(commit=False)
+    if errors:
+        return JsonResponse({'status': False,
+                            'form_errors': errors})
 
     try:
-        return JsonResponse({'status':True, 'data':provider.retrieve_config(test=True)})
+        return JsonResponse({'status':True, 'data':OpenIDRepository.retrieve_config(request.POST.get('provider_url'), use_proxy=False, verify_certificate=False)})
     except Exception as e:
         logger.exception(e)
         return JsonResponse({'status': False, 'error': str(e)})

--- a/vulture_os/authentication/openid/views.py
+++ b/vulture_os/authentication/openid/views.py
@@ -103,13 +103,16 @@ def edit(request, object_id=None, api=False):
 
 
 def test_provider(request):
-    form = OpenIDRepositoryForm(request.POST)
+    provider = OpenIDRepository.objects.filter(provider=request.POST.get('provider'), client_id=request.POST.get('client_id'), client_secret=request.POST.get('client_secret')).first()
 
-    if not form.is_valid():
-        return JsonResponse({'status': False,
-                             'form_errors': form.errors})
+    if not provider:   
+        form = OpenIDRepositoryForm(request.POST)
 
-    provider = form.save(commit=False)
+        if not form.is_valid():
+            return JsonResponse({'status': False,
+                                'form_errors': form.errors})
+
+        provider = form.save(commit=False)
 
     try:
         return JsonResponse({'status':True, 'data':provider.retrieve_config(test=True)})


### PR DESCRIPTION
- Fixed testing already configured OpenID
  - Reason: test_provider function uses a ModelForm from the Model OpenIDRepository that had Unique constraint on the fields: provider, client_id and client_secret.
- Prevented suggestion of previous OpenID client secrets

