### PR TITLE
FIX::Retesting already configured OpenID

### DIFF
--- a/vulture_os/authentication/openid/form.py
+++ b/vulture_os/authentication/openid/form.py
@@ -54,7 +54,7 @@ class OpenIDRepositoryForm(ModelForm):
             'provider': Select(choices=PROVIDERS_TYPE, attrs={'class': 'form-control select2'}),
             'provider_url': TextInput(attrs={'class': 'form-control'}),
             'client_id': TextInput(attrs={'class': 'form-control'}),
-            'client_secret': TextInput(attrs={'class': 'form-control'}),
+            'client_secret': TextInput(attrs={'class': 'form-control','autocomplete': 'off'}),
             'scopes': TextInput(attrs={'class': 'form-control', 'data-role': "tagsinput"}),
             'use_proxy': CheckboxInput(attrs={"class": " js-switch"}),
             'verify_certificate': CheckboxInput(attrs={"class": " js-switch"}),

--- a/vulture_os/authentication/openid/form.py
+++ b/vulture_os/authentication/openid/form.py
@@ -25,7 +25,8 @@ __doc__ = 'OpenIDRepository dedicated form class'
 # Django system imports
 from django.conf import settings
 from django.core.validators import RegexValidator
-from django.forms import CheckboxInput, ModelForm, NumberInput, PasswordInput, Select, TextInput, ModelChoiceField
+from django.forms import CheckboxInput, Form, ModelForm, Select, TextInput
+from django.forms import URLField, BooleanField
 # Django project imports
 from authentication.openid.models import OpenIDRepository, PROVIDERS_TYPE
 from authentication.user_scope.models import UserScope
@@ -88,3 +89,8 @@ class OpenIDRepositoryForm(ModelForm):
             except json.JSONDecodeError:
                 scopes = [i.replace(" ", "") for i in scopes.split(',')]
         return scopes
+
+class OpenIDRepositoryTestForm(Form):
+    provider_url = URLField()
+    use_proxy = BooleanField(required=False)
+    verify_certificate = BooleanField(required=False)

--- a/vulture_os/authentication/openid/models.py
+++ b/vulture_os/authentication/openid/models.py
@@ -224,29 +224,30 @@ class OpenIDRepository(BaseRepository):
         else:
             raise NotImplemented("OTP client type not implemented yet")
 
-    def retrieve_config(self, test=False, force=True):
+    @staticmethod
+    def retrieve_config(provider_url, use_proxy=True, verify_certificate=True ):
+        logger.info(get_proxy() if use_proxy else None)
+        r = requests.get("{}/.well-known/openid-configuration".format(provider_url),
+                            proxies=get_proxy() if use_proxy else None,
+                            verify=verify_certificate, timeout=10)
+        r.raise_for_status()
+        config = r.json()
+        logger.info(config)
+        return config
+
+    def openid_save(self, force=True):
         # TODO : Handle CA_BUNDLE
         # If loaded data is too old, reload it again
         refresh_time = timezone.now() - timedelta(hours=CONFIG_RELOAD_INTERVAL)
-        if (self.last_config_time is None or self.last_config_time < refresh_time)\
-                or test:
-            logger.info(get_proxy() if self.use_proxy else None)
-            r = requests.get("{}/.well-known/openid-configuration".format(self.provider_url),
-                             proxies=get_proxy() if self.use_proxy else None,
-                             verify=self.verify_certificate, timeout=10)
-            r.raise_for_status()
-            config = r.json()
-            logger.info(config)
+        if (self.last_config_time is None or self.last_config_time < refresh_time):
+            config = OpenIDRepository.retrieve_config(self.provider_url, self.use_proxy, self.verify_certificate)
             self.issuer = config['issuer']
             self.authorization_endpoint = config['authorization_endpoint']
             self.token_endpoint = config['token_endpoint']
             self.userinfo_endpoint = config['userinfo_endpoint']
             self.end_session_endpoint = config.get('end_session_endpoint') or config['revocation_endpoint']
             self.last_config_time = timezone.now()
-            if not test:
-                self.save()
-            else:
-                return config
+            self.save()
 
     def get_oauth2_session(self, redirect_uri):
         session = OAuth2Session(self.client_id, redirect_uri=redirect_uri, scope=self.scopes)
@@ -261,11 +262,11 @@ class OpenIDRepository(BaseRepository):
         :param  redirect_uri parameter in authorization_url
         :return tuple authorization_url, state
         """
-        self.retrieve_config()
+        self.openid_save()
         return oauth2_session.authorization_url(self.authorization_endpoint)
 
     def fetch_token(self, oauth2_session, code):
-        self.retrieve_config()
+        self.openid_save()
         return oauth2_session.fetch_token(self.token_endpoint,
                                           code=code,
                                           client_secret=self.client_secret,
@@ -273,7 +274,7 @@ class OpenIDRepository(BaseRepository):
                                           verify=self.verify_certificate)
 
     def get_userinfo(self, oauth2_session):
-        self.retrieve_config()
+        self.openid_save()
         response = oauth2_session.get(self.userinfo_endpoint, verify=self.verify_certificate)
         response.raise_for_status()
         result = response.json()

--- a/vulture_os/authentication/openid/models.py
+++ b/vulture_os/authentication/openid/models.py
@@ -225,8 +225,9 @@ class OpenIDRepository(BaseRepository):
             raise NotImplemented("OTP client type not implemented yet")
 
     @staticmethod
-    def retrieve_config(provider_url, use_proxy=True, verify_certificate=True ):
-        logger.info(get_proxy() if use_proxy else None)
+    def retrieve_config(provider_url, use_proxy=True, verify_certificate=True):
+        logger.info(f"retrieving openid configuration for provider {provider_url}")
+
         r = requests.get("{}/.well-known/openid-configuration".format(provider_url),
                             proxies=get_proxy() if use_proxy else None,
                             verify=verify_certificate, timeout=10)

--- a/vulture_os/authentication/openid/views.py
+++ b/vulture_os/authentication/openid/views.py
@@ -47,9 +47,9 @@ logger = logging.getLogger('gui')
 
 def clone(request, object_id):
     """ LDAPRepository view used to clone an object
-    N.B: Do not totally clone the object and save-it in MongoDB 
+    N.B: Do not totally clone the object and save-it in MongoDB
         because some attributes are unique constraints
- 
+
     :param request: Django request object
     :param object_id: MongoDB object_id of an LDAPRepository object
     """


### PR DESCRIPTION
- Fixed testing already configured OpenID
  - Reason: test_provider function uses a ModelForm from the Model OpenIDRepository that had Unique constraint on the fields: provider, client_id and client_secret.
- Prevented suggestion of previous OpenID client secrets

