### PR TITLE
Api oauth tokens

### DIFF
--- a/vulture_os/authentication/idp/api.py
+++ b/vulture_os/authentication/idp/api.py
@@ -33,7 +33,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.translation import ugettext_lazy as _
 from authentication.user_portal.models import UserAuthentication
 from authentication.totp_profiles.models import TOTPProfile
-from authentication.ldap.tools import NotUniqueError, UserNotExistError
+from authentication.ldap.tools import NotUniqueError, UserDoesntExistError, GroupDoesntExistError
 from authentication.idp.attr_tools import MAPPING_ATTRIBUTES
 from toolkit.portal.registration import perform_email_registration, perform_email_reset
 from toolkit.network.smtp import test_smtp_server
@@ -134,6 +134,12 @@ class IDPApiView(View):
                 "status": False,
                 "error": _("Portal does not exist")
             }, status=404)
+
+        except GroupDoesntExistError:
+            return JsonResponse({
+                "status": True,
+                "data": {}
+            }, status=204)
 
         except Exception as err:
             logger.critical(err, exc_info=1)
@@ -403,7 +409,7 @@ class IDPApiUserView(View):
                 "status": True
             })
 
-        except UserNotExistError:
+        except UserDoesntExistError:
             return JsonResponse({
                 "status": False,
                 "error": _("User not found")

--- a/vulture_os/authentication/idp/api.py
+++ b/vulture_os/authentication/idp/api.py
@@ -23,20 +23,28 @@ __email__ = "contact@vultureproject.org"
 __doc__ = 'IDP API'
 
 import logging
+from authentication.idp.authentication import api_check_authorization
+from base64 import urlsafe_b64decode
+from datetime import timedelta
 from django.views import View
 from django.conf import settings
 from authentication.ldap import tools
 from django.http import JsonResponse
 from gui.decorators.apicall import api_need_key
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.translation import ugettext_lazy as _
+from authentication.base_repository import BaseRepository
 from authentication.user_portal.models import UserAuthentication
 from authentication.totp_profiles.models import TOTPProfile
 from authentication.ldap.tools import NotUniqueError, UserDoesntExistError, GroupDoesntExistError
 from authentication.idp.attr_tools import MAPPING_ATTRIBUTES
+from oauth2.tokengenerator import Uuid4
+from portal.system.redis_sessions import REDISOauth2Session, REDISBase
 from toolkit.portal.registration import perform_email_registration, perform_email_reset
 from toolkit.network.smtp import test_smtp_server
+from uuid import UUID
 
 from system.cluster.models import Cluster
 
@@ -45,8 +53,17 @@ logging.config.dictConfig(settings.LOG_SETTINGS)
 logger = logging.getLogger('api')
 
 
-def get_repo(portal, repo_id):
+def get_repo_by_id(portal, repo_id):
     return portal.repositories.get(subtype="LDAP", pk=repo_id).get_daughter()
+
+def get_repo_by_name(portal, repo_name):
+    return portal.repositories.get(subtype="LDAP", name=repo_name).get_daughter()
+
+
+class ActionForbiddenException(Exception):
+    def __init__(self, message="Forbidden"):
+        self.message = message
+        super().__init__(self.message)
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -55,7 +72,7 @@ class IDPApiView(View):
     def get(self, request, portal_id, repo_id):
         try:
             portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo(portal, repo_id)
+            ldap_repo = get_repo_by_id(portal, repo_id)
 
             object_type = request.GET["object_type"].lower()
             if object_type not in ("users", "search"):
@@ -158,7 +175,7 @@ class IDPApiUserView(View):
     def post(self, request, portal_id, repo_id, action=None):
         try:
             portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo(portal, repo_id)
+            ldap_repo = get_repo_by_id(portal, repo_id)
 
             if action and action not in ("resend_registration", "reset_password", "lock", "unlock", "reset_otp"):
                 return JsonResponse({
@@ -326,7 +343,7 @@ class IDPApiUserView(View):
     def put(self, request, portal_id, repo_id):
         try:
             portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo(portal, repo_id)
+            ldap_repo = get_repo_by_id(portal, repo_id)
 
             user_dn = request.JSON['id']
 
@@ -399,7 +416,8 @@ class IDPApiUserView(View):
     def delete(self, request, portal_id, repo_id):
         try:
             portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo(portal, repo_id)
+            ldap_repo = get_repo_by_id(portal, repo_id)
+            redis_handler = REDISBase()
 
             user_dn = request.JSON['id']
             logger.info(f"IDPApiUserView::DELETE::[{portal.name}/{ldap_repo}] Request to remove user {user_dn}")
@@ -411,6 +429,18 @@ class IDPApiUserView(View):
                     "error": _("User not found")
                 }, status=404)
             logger.info(f"IDPApiUserView::DELETE::[{portal.name}/{ldap_repo}] Removed user {user_dn}")
+
+            # Search and remove all related oauth2 tokens
+            logger.info(f"IDPApiUserView::DELETE::[{portal.name}/{ldap_repo}] Removing user {user_dn} related oauth tokens")
+            all_tokens = redis_handler.scan_all("oauth2_*", type="hash")
+            for token in all_tokens:
+                repo = redis_handler.hget(token, "repo")
+                sub = redis_handler.hget(token, "sub")
+
+                if repo == portal.oauth_client_id and sub == user_dn:
+                    logger.info(f"IDPApiUserView::DELETE::[{portal.name}/{ldap_repo}] Removing oauth token {token} from deleted user {user_dn}")
+                    redis_handler.delete(token)
+                    redis_handler.delete(f"{token}_{repo}")
 
             return JsonResponse({
                 "status": True
@@ -444,3 +474,276 @@ class IDPApiUserView(View):
                 "status": False,
                 "error": str(err)
             }, status=500)
+
+
+def _validate_request(request, user_b64, portal_id=None, repo_id=None, portal_name=None, repo_name=None, token_key=None):
+    # parameters
+    if portal_id:
+        portal = UserAuthentication.objects.get(pk=portal_id)
+    elif portal_name:
+        portal = UserAuthentication.objects.get(name=portal_name)
+    else:
+        raise ValueError("Need a portal id or name to scope token on")
+
+    if repo_id:
+        repo = get_repo_by_id(portal, repo_id)
+    elif repo_name:
+        repo = get_repo_by_name(portal, repo_name)
+    else:
+        raise ValueError("Need a repo id or name to scope token on")
+
+    user_dn = urlsafe_b64decode(user_b64).decode("utf-8")
+    user = tools.get_user_by_dn(repo, user_dn)
+    scopes = portal.get_user_scope({}, user)
+    assert 'sub' in scopes, "Cannot create token: IDP's scoping doesn't define a valid 'sub'"
+
+    if token_key:
+        try:
+            UUID(token_key, version=4)
+        except ValueError:
+            raise ValueError("token's format is invalid")
+
+    # data
+    timeout = request.JSON.get("timeout", portal.oauth_timeout)
+
+    # Auth
+    auth_token = request.auth_token
+    sub = auth_token.keys.get("sub")
+    assert sub != None, "No 'sub' in authentication token, cannot establish user's identity"
+
+    if sub != user_dn:
+        logger.warning(f"User '{sub}' cannot create a token for user {user_dn}")
+        raise ActionForbiddenException("Cannot modify tokens for another user")
+
+    return portal, repo, user_dn, timeout, scopes
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class IDPApiUserTokenView(View):
+
+    @api_need_key('cluster_api_key')
+    @api_check_authorization()
+    def post(self, request, user_b64, portal_id=None, repo_id=None, portal_name=None, repo_name=None):
+        try:
+            portal, repo, user_dn, timeout, scopes = _validate_request( request,
+                                                                        user_b64,
+                                                                        portal_id=portal_id,
+                                                                        repo_id=repo_id,
+                                                                        portal_name=portal_name,
+                                                                        repo_name=repo_name)
+            # All validation is done, creating token
+            token_key = Uuid4().generate()
+            token = REDISOauth2Session(REDISBase(), f"oauth2_{token_key}")
+            logger.info(f"IDPApiUserTokenView::POST::[{portal.name}/{repo}] Creating token {token_key} "
+                        f"with scopes {scopes}, expiring in {timeout}s, for user {user_dn}")
+            token.register_authentication(
+                portal.oauth_client_id,
+                scopes,
+                timeout
+            )
+            expireat = timezone.now() + timedelta(seconds=timeout)
+
+        except UserAuthentication.DoesNotExist:
+            logger.warning(f"IDPApiUserTokenView::POST:: Tried to access unknown resource: "
+                            f"portal {portal_id or portal_name}")
+            return JsonResponse({
+                "status": False,
+                "error": _("Portal does not exist")
+            }, status=404)
+        except BaseRepository.DoesNotExist:
+            logger.warning(f"IDPApiUserTokenView::POST:: "
+                            f"Tried to access unknown resource: repo {repo_id or repo_name}")
+            return JsonResponse({
+                "status": False,
+                "error": _("Repository does not exist")
+            }, status=404)
+        except UserDoesntExistError as e:
+            logger.warning(f"IDPApiUserTokenView::POST:: "
+                            f"Tried to access unknown resource: user {e.user_dn}")
+            return JsonResponse({
+                "status": False,
+                "error": _("User does not exist")
+            }, status=404)
+        except ActionForbiddenException as e:
+            logger.warning(f"IDPApiUserTokenView::POST:: {str(e)}")
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=403)
+        except (AssertionError, ValueError) as e:
+            logger.warning(f"IDPApiUserTokenView::POST:: {str(e)}")
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=400)
+        except Exception as e:
+            logger.exception(e)
+            return JsonResponse({
+                "status": False,
+                "error": _("An unknown error occured")
+            }, status=500)
+
+        return JsonResponse({
+            "status": True,
+            "expireat": int(expireat.timestamp()),
+            "token": token_key
+        }, status=201)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class IDPApiUserTokenModificationView(View):
+    @api_need_key('cluster_api_key')
+    @api_check_authorization()
+    def patch(self, request, user_b64, token_key, portal_id=None, repo_id=None, portal_name=None, repo_name=None):
+        try:
+            token_key = str(token_key)
+            portal, repo, user_dn, timeout, scopes = _validate_request( request,
+                                                                        user_b64,
+                                                                        portal_id=portal_id,
+                                                                        repo_id=repo_id,
+                                                                        portal_name=portal_name,
+                                                                        repo_name=repo_name,
+                                                                        token_key=token_key)
+            # All validation is done, creating token
+            token = REDISOauth2Session(REDISBase(), f"oauth2_{token_key}")
+            if not token.exists():
+                logger.warning(f"IDPApiUserTokenModificationView::PATCH::[{portal.name}/{repo}] User '{user_dn}' "
+                                f"Trying to refresh a token that doesn't exist '{token_key}'")
+                return JsonResponse({
+                    "status": False
+                }, status=404)
+            elif token.keys.get("sub") != user_dn:
+                logger.error(f"IDPApiUserTokenModificationView::PATCH::[{portal.name}/{repo}] User '{user_dn}' "
+                                f"is trying to override token '{token_key}', owned by '{token.keys.get('sub')}'!")
+                return JsonResponse({
+                    "status": False
+                }, status=404)
+            logger.info(f"IDPApiUserTokenModificationView::PATCH::[{portal.name}/{repo}] Updating token {token_key} "
+                        f"with scopes {scopes}, expiring in {timeout}s, for user {user_dn}")
+            token.register_authentication(
+                portal.oauth_client_id,
+                scopes,
+                timeout
+            )
+            expireat = timezone.now() + timedelta(seconds=timeout)
+
+        except UserAuthentication.DoesNotExist:
+            logger.warning(f"IDPApiUserTokenModificationView::PATCH:: Tried to access unknown resource: "
+                            f"portal {portal_id or portal_name}")
+            return JsonResponse({
+                "status": False,
+                "error": _("Portal does not exist")
+            }, status=404)
+        except BaseRepository.DoesNotExist:
+            logger.warning(f"IDPApiUserTokenModificationView::PATCH:: Tried to access unknown resource: "
+                            f"repo {repo_id or repo_name}")
+            return JsonResponse({
+                "status": False,
+                "error": _("Repository does not exist")
+            }, status=404)
+        except UserDoesntExistError as e:
+            logger.warning(f"IDPApiUserTokenModificationView::PATCH:: "
+                            f"Tried to access unknown resource: user {e.user_dn}")
+            return JsonResponse({
+                "status": False,
+                "error": _("User does not exist")
+            }, status=404)
+        except ActionForbiddenException as e:
+            logger.warning(f"IDPApiUserTokenModificationView::PATCH:: {str(e)}")
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=403)
+        except (AssertionError, ValueError) as e:
+            logger.warning(f"IDPApiUserTokenModificationView::PATCH:: {str(e)}")
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=400)
+        except Exception as e:
+            logger.exception(e)
+            return JsonResponse({
+                "status": False,
+                "error": _("An unknown error occured")
+            }, status=500)
+
+        return JsonResponse({
+            "status": True,
+            "expireat": int(expireat.timestamp()),
+            "token": token_key
+        }, status=201)
+
+
+    @api_need_key('cluster_api_key')
+    @api_check_authorization()
+    def delete(self, request, user_b64, token_key, portal_id=None, repo_id=None, portal_name=None, repo_name=None):
+        try:
+            token_key = str(token_key)
+            portal, repo, user_dn, timeout, scopes = _validate_request( request,
+                                                                        user_b64,
+                                                                        portal_id=portal_id,
+                                                                        repo_id=repo_id,
+                                                                        portal_name=portal_name,
+                                                                        repo_name=repo_name,
+                                                                        token_key=token_key)
+            # All validation is done, creating token
+            token = REDISOauth2Session(REDISBase(), f"oauth2_{token_key}")
+            if not token.exists():
+                logger.warning(f"IDPApiUserTokenModificationView::DELETE::[{portal.name}/{repo}] "
+                                f"User {user_dn} trying to delete token that doesn't exist '{token_key}'")
+                return JsonResponse({
+                    "status": False
+                }, status=404)
+            elif token.keys.get("sub") != user_dn:
+                logger.error(f"IDPApiUserTokenModificationView::DELETE::[{portal.name}/{repo}] User '{user_dn}' "
+                                f"is trying to delete token '{token_key}', owned by '{token.keys.get('sub')}'!")
+                return JsonResponse({
+                    "status": False
+                }, status=404)
+            logger.info(f"IDPApiUserTokenModificationView::DELETE::[{portal.name}/{repo}] "
+                            f"Deleting token {token_key} for user {user_dn}")
+            token.delete()
+
+        except UserAuthentication.DoesNotExist:
+            logger.warning(f"IDPApiUserTokenModificationView::DELETE:: "
+                            f"Tried to access unknown resource: portal {portal_id or portal_name}")
+            return JsonResponse({
+                "status": False,
+                "error": _("Portal does not exist")
+            }, status=404)
+        except BaseRepository.DoesNotExist:
+            logger.warning(f"IDPApiUserTokenModificationView::DELETE:: "
+                            f"Tried to access unknown resource: repo {repo_id or repo_name}")
+            return JsonResponse({
+                "status": False,
+                "error": _("Repository does not exist")
+            }, status=404)
+        except UserDoesntExistError as e:
+            logger.warning(f"IDPApiUserTokenModificationView::DELETE:: "
+                            f"Tried to access unknown resource: user {e.user_dn}")
+            return JsonResponse({
+                "status": False,
+                "error": _("User does not exist")
+            }, status=404)
+        except ActionForbiddenException as e:
+            logger.warning(f"IDPApiUserTokenModificationView::DELETE:: {str(e)}")
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=403)
+        except (AssertionError, ValueError) as e:
+            logger.warning(f"IDPApiUserTokenModificationView::DELETE:: {str(e)}")
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=400)
+        except Exception as e:
+            logger.exception(e)
+            return JsonResponse({
+                "status": False,
+                "error": _("An unknown error occured")
+            }, status=500)
+
+        return JsonResponse({
+            "status": True,
+        }, status=204)

--- a/vulture_os/authentication/idp/api.py
+++ b/vulture_os/authentication/idp/api.py
@@ -64,7 +64,7 @@ class IDPApiView(View):
             if object_type == "users":
                 data = []
                 group_name = f"{ldap_repo.group_attr}={portal.group_registration}"
-                tmp_data = tools.get_users(ldap_repo, group_name)
+                tmp_data = tools.get_users_in_group(ldap_repo, group_name)
 
                 for tmp in tmp_data:
                     tmp_user = {

--- a/vulture_os/authentication/idp/authentication.py
+++ b/vulture_os/authentication/idp/authentication.py
@@ -1,0 +1,84 @@
+#!/home/vlt-os/env/bin/python
+"""This file is part of Vulture OS.
+
+Vulture OS is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vulture OS is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vulture OS.  If not, see http://www.gnu.org/licenses/.
+"""
+__author__ = "Theo BERTIN"
+__credits__ = []
+__license__ = "GPLv3"
+__version__ = "3.0.0"
+__maintainer__ = "Vulture OS"
+__email__ = "contact@vultureproject.org"
+__doc__ = 'IDP API AUTHENTICATION'
+
+import logging
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
+from functools import wraps
+from django.utils.translation import ugettext_lazy as _
+from portal.system.redis_sessions import REDISOauth2Session, REDISBase
+
+logging.config.dictConfig(settings.LOG_SETTINGS)
+logger = logging.getLogger('api')
+
+class HttpResponseUnauthorized(HttpResponse):
+    def __init__(self):
+        super().__init__('401 Unauthorized', status=401)
+        # if not hasattr(self, 'headers'):
+        #     self.headers = {}
+        self["WWW-Authenticate"] = "Please provide an 'Authorization' header with a valid token"
+
+def api_check_authorization():
+    """ Decorator used to check if the given API Key is correct
+    passed in
+    :param group_names: List of groups
+    :return:
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def inner(cls_or_request, *args, **kwargs):
+            request = None
+
+            if not isinstance(cls_or_request, HttpRequest):
+                if not isinstance(args[0], HttpRequest):
+                    logger.error("API Call without request object : {} and {}".format(cls_or_request, request))
+                    return HttpResponseUnauthorized()
+                else:
+                    request = args[0]
+            else:
+                request = cls_or_request
+
+            api_key = request.headers.get("authorization")
+            if not api_key:
+                logger.error(
+                    "API Call without valid 'Authorization' header. Method (%s): %s", request.method, request.path,
+                    extra={'status_code': 401, 'request': request}
+                )
+                return HttpResponseUnauthorized()
+
+            api_key = api_key.replace("Bearer ", "")
+
+            token = REDISOauth2Session(REDISBase(), f"oauth2_{api_key}")
+            if not token.exists():
+                logger.warning(f"Invalid token in API call: {api_key}")
+                return HttpResponseForbidden()
+
+            request.auth_token = token
+
+            return func(request, *args, **kwargs)
+
+        return inner
+    return decorator

--- a/vulture_os/authentication/idp/urls.py
+++ b/vulture_os/authentication/idp/urls.py
@@ -24,7 +24,7 @@ __doc__ = 'IDP URLS'
 
 from django.urls import path, re_path
 
-from authentication.idp.api import IDPApiView, IDPApiUserView
+from authentication.idp.api import IDPApiView, IDPApiUserView, IDPApiUserTokenView, IDPApiUserTokenModificationView
 
 urlpatterns = [
    re_path('^api/v1/authentication/idp/(?P<portal_id>[A-Fa-f0-9]+)/(?P<repo_id>[A-Fa-f0-9]+)/$', IDPApiView.as_view(), name="authentication.idp"),
@@ -33,5 +33,19 @@ urlpatterns = [
 
    path('api/v1/authentication/idp/users/<int:portal_id>/<int:repo_id>/<str:action>/',
         IDPApiUserView.as_view(),
-        name="authentication.idp.users.action")
+        name="authentication.idp.users.action"),
+
+   path('api/v1/authentication/idp/<int:portal_id>/repos/<int:repo_id>/users/<str:user_b64>/tokens/',
+        IDPApiUserTokenView.as_view(),
+        name="authentication.idp.users.token"),
+   path('api/v1/authentication/idp/<str:portal_name>/repos/<str:repo_name>/users/<str:user_b64>/tokens/',
+        IDPApiUserTokenView.as_view(),
+        name="authentication.idp.users.token"),
+
+   path('api/v1/authentication/idp/<int:portal_id>/repos/<int:repo_id>/users/<str:user_b64>/tokens/<uuid:token_key>/',
+        IDPApiUserTokenModificationView.as_view(),
+        name="authentication.idp.users.token"),
+   path('api/v1/authentication/idp/<str:portal_name>/repos/<str:repo_name>/users/<str:user_b64>/tokens/<uuid:token_key>/',
+        IDPApiUserTokenModificationView.as_view(),
+        name="authentication.idp.users.token"),
 ]

--- a/vulture_os/authentication/ldap/tools.py
+++ b/vulture_os/authentication/ldap/tools.py
@@ -40,7 +40,10 @@ class NotUniqueError(Exception):
     pass
 
 
-class UserNotExistError(Exception):
+class UserDoesntExistError(Exception):
+    pass
+
+class GroupDoesntExistError(Exception):
     pass
 
 
@@ -87,12 +90,8 @@ def _find_group(ldap_repo, group_dn, attr_list):
 
 
 def _create_user(ldap_repository, user_dn, username, userPassword, attrs, group_dn=False):
-    try:
-        if _find_user(ldap_repository, user_dn, ["*"]):
-            raise NotUniqueError(user_dn)
-    except IndexError:
-        # User does not exists
-        pass
+    if _find_user(ldap_repository, user_dn, ["*"]):
+        raise NotUniqueError(user_dn)
 
     user = {
         "sn": [username],
@@ -133,6 +132,8 @@ def search_users(ldap_repo, search, by_dn=False):
 def get_users(ldap_repository, group_name):
     group_dn = f"{group_name},{ldap_repository.get_client()._get_group_dn()}"
     group = _find_group(ldap_repository, group_dn, ['*'])
+    if not group:
+        raise GroupDoesntExistError(f"Group {group_name} doesn't exist")
     members  = []
     for member_dn in group['member']:
         members.append(_find_user(ldap_repository, member_dn, ["+", "*"]))
@@ -156,7 +157,7 @@ def find_user_email(ldap_repository, username):
     # No need to construct the scope, search_user does-it automatically...
     user = ldap_repository.get_client().search_user(username, attr_list=[ldap_repository.user_email_attr])
     if not user:
-        raise UserNotExistError()
+        raise UserDoesntExistError()
     dn = user[0][0]
     mail = user[0][1][ldap_repository.user_email_attr]
     return dn, mail[0] if isinstance(mail, list) else mail
@@ -174,7 +175,7 @@ def create_user(ldap_repository, username, userPassword, attrs, group=False):
 def lock_unlock_user(ldap_repository, user_dn, lock=True):
     user = _find_user(ldap_repository, user_dn, ["*"])
     if not user:
-        raise UserNotExistError()
+        raise UserDoesntExistError()
 
     if not lock:
         logger.debug(f"Unlocking user {user_dn}")
@@ -190,11 +191,8 @@ def lock_unlock_user(ldap_repository, user_dn, lock=True):
 
 
 def update_user(ldap_repository, user_dn, attrs, userPassword):
-    try:
-        old_user = _find_user(ldap_repository, user_dn, ["*"])
-        if not old_user:
-            raise IndexError()
-    except IndexError:
+    old_user = _find_user(ldap_repository, user_dn, ["*"])
+    if not old_user:
         # attrs[ldap_repository.user_attr] is the username
         # update_user should return a key error if it doesn't exist (cannot create an user without it)
         return _create_user(ldap_repository, user_dn, attrs[ldap_repository.user_attr], userPassword, attrs)
@@ -227,12 +225,9 @@ def update_user(ldap_repository, user_dn, attrs, userPassword):
 def delete_user(ldap_repository, user_dn):
     client = ldap_repository.get_client()
 
-    try:
-        old_user = _find_user(ldap_repository, user_dn, ["*"])
-        if not old_user:
-            raise UserNotExistError()
-    except IndexError:
-            raise UserNotExistError()
+    old_user = _find_user(ldap_repository, user_dn, ["*"])
+    if not old_user:
+        raise UserDoesntExistError()
 
     groups = [_find_group(ldap_repository, group_dn, ["*"]) for group_dn in client.search_user_groups_by_dn(user_dn)]
     r = client.delete_user(user_dn, groups)

--- a/vulture_os/authentication/ldap/tools.py
+++ b/vulture_os/authentication/ldap/tools.py
@@ -49,8 +49,10 @@ class GroupDoesntExistError(Exception):
 
 def _find_user(ldap_repo, user_dn, attr_list):
     client = ldap_repo.get_client()
-    user = client.search_by_dn(user_dn, attr_list=attr_list)
-    dn, attrs = user[0]
+    dn, attrs = client.search_by_dn(user_dn, attr_list=attr_list)
+    if not dn:
+        return None
+
     user = {"dn": dn}
 
     for key in AVAILABLE_USER_KEYS:
@@ -75,9 +77,10 @@ def _find_user(ldap_repo, user_dn, attr_list):
 
 def _find_group(ldap_repo, group_dn, attr_list):
     client = ldap_repo.get_client()
-    group = client.search_by_dn(group_dn, attr_list=attr_list)
+    dn, attrs = client.search_by_dn(group_dn, attr_list=attr_list)
+    if not dn:
+        return None
 
-    dn, attrs = group[0]
     group = {"dn": dn}
 
     for key in AVAILABLE_GROUP_KEYS:
@@ -129,7 +132,7 @@ def search_users(ldap_repo, search, by_dn=False):
     return data
 
 
-def get_users(ldap_repository, group_name):
+def get_users_in_group(ldap_repository, group_name):
     group_dn = f"{group_name},{ldap_repository.get_client()._get_group_dn()}"
     group = _find_group(ldap_repository, group_dn, ['*'])
     if not group:

--- a/vulture_os/authentication/ldap/tools.py
+++ b/vulture_os/authentication/ldap/tools.py
@@ -144,6 +144,19 @@ def search_users(ldap_repo, search, by_dn=False):
     return data
 
 
+def get_user_by_dn(ldap_repo, dn, attrs_list=["+", "*"]):
+    user = _find_user(ldap_repo, dn, attrs_list)
+    if not user:
+        raise UserDoesntExistError(dn=dn)
+
+    # cleaning values to avoid lists of 1 element
+    for key, value in user.items():
+        if isinstance(value, list):
+            user[key] = value[0]
+
+    return user
+
+
 def get_users_in_group(ldap_repository, group_name):
     group_dn = f"{group_name},{ldap_repository.get_client()._get_group_dn()}"
     group = _find_group(ldap_repository, group_dn, ['*'])

--- a/vulture_os/authentication/user_portal/models.py
+++ b/vulture_os/authentication/user_portal/models.py
@@ -631,11 +631,8 @@ class UserAuthentication(models.Model):
         return self.portal_template.render_template(tpl_name, **{**kwargs, **self.to_template()})
 
     def get_user_scope(self, claims, repo_attrs):
-        user_scope = {}
         if self.user_scope:
-            for u in self.user_scope.get_repo_attributes():
-                user_scope = u.get_scope(user_scope, claims, repo_attrs)
-            return user_scope
+            return self.user_scope.get_user_scope(claims, repo_attrs)
         else:
             return claims
 

--- a/vulture_os/portal/system/authentications.py
+++ b/vulture_os/portal/system/authentications.py
@@ -169,16 +169,14 @@ class Authentication(object):
         logger.debug("AUTH::register_user: token successfuly created")
 
     def register_user(self, authentication_results, oauth2_scope):
+        if self.workflow.authentication.enable_oauth:
         # Mandatory claims for SSO-F, OTP, change password, etc
-        if self.workflow.authentication.enable_external:
-            if not oauth2_scope.get('name'):
-                oauth2_scope['name'] = self.credentials[0]
+            if not oauth2_scope.get('sub'):
+                oauth2_scope['sub'] = authentication_results.get('sub', authentication_results.get("dn", ""))
             if not oauth2_scope.get('user_email'):
                 oauth2_scope['user_email'] = authentication_results.get('user_email', "")
             if not oauth2_scope.get('user_phone'):
                 oauth2_scope['user_phone'] = authentication_results.get('user_phone', "")
-
-        if self.workflow.authentication.enable_oauth:
             logger.info(f"AUTH::register_user: Oauth enabled for {self.workflow.authentication.name}, creating oauth2 token")
             self.write_oauth2_session(oauth2_scope)
 

--- a/vulture_os/portal/system/authentications.py
+++ b/vulture_os/portal/system/authentications.py
@@ -206,7 +206,7 @@ class Authentication(object):
         oauth2_scope = self.redis_portal_session.get_user_infos(backend_id)
 
         if self.workflow.authentication.enable_oauth:
-            logger.info(f"AUTH::register_user: Oauth enabled for {self.workflow.authentication.name}, creating oauth2 token")
+            logger.info(f"AUTH::register_sso: Oauth enabled for {self.workflow.authentication.name}, creating oauth2 token")
             self.write_oauth2_session(oauth2_scope)
 
         password = self.redis_portal_session.getAutologonPassword(self.workflow.id, backend_id, username)

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -71,6 +71,9 @@ class REDISSession(object):
     def __getitem__(self, key):
         return self.keys.get(key)
 
+    def exists(self):
+        return self.handler.exists(self.key)
+
     def set_ttl(self, ttl):
         if self.handler.ttl(self.key) < ttl:
             return self.handler.expire(self.key, ttl)

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -512,12 +512,15 @@ class REDISOauth2Session(REDISSession):
         else:
             if not self.keys.get('scope'):
                 self.keys['scope'] = {}
-            if not self.keys.get('token_ttl'):
-                self.keys['token_ttl'] = timeout
-                self.keys['iat'] = int(time.time())
-                self.keys['exp'] = int(time.time()) + timeout
             if not self.keys.get('repo'):
                 self.keys['repo'] = repo_id
+            if not self.keys.get('sub') and sub:
+                self.keys['sub'] = sub
+
+            self.keys['token_ttl'] = timeout
+            self.keys['iat'] = int(time.time())
+            self.keys['exp'] = int(time.time()) + timeout
+
             for key,item in oauth2_data.items():
                 self.keys['scope'][key] = item
         if not self.write_in_redis(timeout):

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -92,7 +92,6 @@ class REDISSession(object):
             self.handler.expire(key, timeout)
 
     def delete_in_redis(self, key):
-        logger.error(f"deleting {key} in redis")
         return self.handler.delete(key)
 
 
@@ -547,8 +546,8 @@ class RedisOpenIDSession(REDISSession):
 
         # This is a temporary token, used for redirection and access_token retrieve
         if not self.write_in_redis(30):
-            logger.error("REDIS::register: Error while writing portal_session in Redis")
-            raise REDISWriteError("REDISOauth2Session::register: Unable to write Oauth2 infos in REDIS")
+            logger.error("RedisOpenIDSession::register: Error while writing portal_session in Redis")
+            raise REDISWriteError("RedisOpenIDSession::register: Unable to write Oauth2 infos in REDIS")
 
         return self.key
 

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -773,6 +773,18 @@ class REDISBase(object):
     def hscan(self, hash, cursor=0, match=None, count=None):
         return self.r.hscan(hash, cursor, match, count)
 
+    # Scan continuously to receive all keys matching parameters
+    def scan_all(self, pattern=None, type=None):
+        result = list()
+        partial_result = self.r.scan(0, match=pattern, _type=type)
+        cursor = partial_result[0]
+        result.extend(partial_result[1])
+        while cursor != 0:
+            partial_result = self.r.scan(cursor, match=pattern, _type=type)
+            cursor = partial_result[0]
+            result.extend(partial_result[1])
+
+        return result
 
     def keys(self, pattern):
         return self.r.keys(pattern)

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -497,6 +497,7 @@ class REDISOauth2Session(REDISSession):
         return ret
 
     def register_authentication(self, repo_id, oauth2_data, timeout):
+        sub = oauth2_data.get('sub')
         data = {
             'token_ttl': timeout,
             'iat': int(time.time()),
@@ -504,6 +505,8 @@ class REDISOauth2Session(REDISSession):
             'scope': oauth2_data,
             'repo': str(repo_id)
         }
+        if sub:
+            data.update({'sub': sub})
         if not self.keys:
             self.keys = data
         else:

--- a/vulture_os/portal/system/redis_sessions.py
+++ b/vulture_os/portal/system/redis_sessions.py
@@ -499,6 +499,11 @@ class REDISOauth2Session(REDISSession):
 
         return ret
 
+    def delete(self):
+        if repo := self.keys.get('repo'):
+            self.delete_in_redis(f"{self.key}_{repo}")
+        self.delete_in_redis(self.key)
+
     def register_authentication(self, repo_id, oauth2_data, timeout):
         sub = oauth2_data.get('sub')
         data = {

--- a/vulture_os/portal/views/logon.py
+++ b/vulture_os/portal/views/logon.py
@@ -227,9 +227,9 @@ def openid_callback(request, workflow_id, repo_id):
 
         # Set authentication attributes required
         authentication.backend_id = repo_id
-        authentication.credentials = [str(claims.get('name') or claims.get('sub')), ""]
-        if not user_scope.get('name'):
-            user_scope['name'] = str(claims.get('name') or claims.get('sub'))
+        authentication.credentials = [str(claims.get('sub') or claims.get('name')), ""]
+        if not user_scope.get('sub'):
+            user_scope['sub'] = str(claims.get('sub') or claims.get('name'))
         portal_cookie, oauth2_token = authentication.register_user({**claims, **repo_attributes}, user_scope)
 
     except KeyError as e:

--- a/vulture_os/toolkit/auth/ldap_client.py
+++ b/vulture_os/toolkit/auth/ldap_client.py
@@ -671,26 +671,9 @@ class LDAPClient(BaseAuth):
     def _format_user_results(self, user_dn, user_attrs):
         res = {}
         user_groups = []
+        user_attrs = _DeepStringCoder("utf-8").decode(user_attrs)
         # Standardize attributes
         for key, val in user_attrs.items():
-            # decode all bytes entries
-            if isinstance(val, bytes):
-                try:
-                    val = val.decode('utf-8')
-                except UnicodeDecodeError:
-                    logger.warning(f"ldap_client::_format_user_results:: ignoring key {key} -> cannot decode")
-                    continue
-            if isinstance(val, list):
-                for subval in val:
-                    if isinstance(subval, bytes):
-                        try:
-                            i = val.index(subval)
-                            val.pop(i)
-                            val.insert(i, subval.decode('utf-8'))
-                        except UnicodeDecodeError:
-                            logger.warning(f"ldap_client::_format_user_results:: ignoring value in key {key} -> cannot decode")
-                            continue
-
             if key == "userPassword":
                 continue
             elif key == self.user_groups_attr:

--- a/vulture_os/toolkit/auth/ldap_client.py
+++ b/vulture_os/toolkit/auth/ldap_client.py
@@ -32,6 +32,7 @@ import copy
 import ldap
 import ldap.modlist as modlist
 from ldap.filter import escape_filter_chars
+from ldap.dn import escape_dn_chars
 
 
 # Required exceptions imports
@@ -338,7 +339,7 @@ class LDAPClient(BaseAuth):
         :return: An list with results if query match, None otherwise
         """
         # input sanitation
-        username = escape_filter_chars(username)
+        username = escape_dn_chars(username)
         logger.debug(f"Searching for user {username} and getting attributes {attr_list}")
         # Defining user search filter
         query_filter = "({}={})".format(self.user_attr, username)

--- a/vulture_os/toolkit/auth/ldap_client.py
+++ b/vulture_os/toolkit/auth/ldap_client.py
@@ -325,12 +325,12 @@ class LDAPClient(BaseAuth):
         self._bind_connection(self.user, self.password)
         try:
             result = self._get_connection().search_s(dn, ldap.SCOPE_SUBTREE, '(objectClass=*)', attr_list)
-            results = self._process_results(result)
+            dn, attrs = (result[0][0], self._process_results(result[0][1]))
         except ldap.NO_SUCH_OBJECT:
-            results = []
+            dn, attrs = (None, None)
 
         self.unbind_connection()
-        return results
+        return dn, attrs
 
     def search_user(self, username, attr_list=None):
         """ Method used to search for a user inside LDAP repository

--- a/vulture_os/vulture_os/settings.py
+++ b/vulture_os/vulture_os/settings.py
@@ -142,6 +142,8 @@ DATABASES = {
     }
 }
 
+REDISIP = '127.0.0.1'
+REDISPORT = '6379'
 
 LOGIN_URL = "/login/"
 


### PR DESCRIPTION
### Fixed
- [LDAP_CLIENT] Use escape_dn_chars() instead of escape_filter_chars() in search_user() for sanitation
- [OAUTH] Ensure 'sub' is present in oauth2 tokens

### Changed
- [IDP_API] Improved logging to include systematic portal, repo, user (when available) and action

### Added
- [IDP] [API] New APIs to manage oauth2 tokens creation
  - Create a new token for a specific user, on a specific portal and repository
  - User must authenticate themselves with a valid oauth token
  - Claims will be created using internal repository data and IDP scope filtering
  - Expiration time can be overridden during POST/PATCH
  - Tokens can be deleted by user, they will be removed if user is removed
- [LDAP] [TOOLS] Utility function to get a user by its full DN
- [REDIS] [TOKENS] Utility function to check if a key exists in Redis
- [REDISOAUTH2SESSION] Utility function to delete an existing key and its subordinate(s)
- [REDIS] [BASE] New scan_all() utility function to get all keys with possible matching pattern and type