### PR TITLE
Version 2.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.1] - 2022-10-19
+### Fixed
+- [PORTAL] [SSO] SSO could fail when portal have no oauth2 activated
+- [PORTAL] Correctly refresh session timeout only when necessary
+- [APACHE] [CONFIGURATION] Update Apache WSGI's configuration to allow code to read 'Authorization' header
+- [API_PARSER] [SENTINEL_ONE] Avoid parser getting stuck after not having received any logs for more than 24h
+- [API_PARSER] [GSUITE] Parser failure caused by wrong 'since' variable type
+- [API_PARSER] [CROWDSTRIKE] Parser failure caused by wrong 'since' variable type
+- [USER_PORTAL] [API] Could not get all portals through API when no ID/name was specified
+- [PORTAL] Validate session Cookies, then Vulture Headers, then 'Authorization' Header during session validation
+   - Allows protected applications to use 'Authorization' Headers when a user browses it with a web session
+### Added
+- [UPGRADE] Added bash script to uninstall python 3.8 and install generic python in apache and portal jail
+- [IDP_USERS] Support for new API paths
+  - Added paths for uniformization with new /tokens endpoints
+  - Ability to use portal/repo names in queries
+### Changed
+- [PORTAL] [LOGGING] Improved logging and details in case of errors
+- [DEPENDENCY] Changed uses of python 3.8 to generic python3 to use the default python version for the system (ie python 3.8 for HBSD12 and 3.9 for HBSD13)
+### Removed
+- [PKG_UPGRADE] Don't rebuild python env using `virtualenv`, binaries are no longer symlinked
+
+
 ## [2.1.0] - 2022-09-27
 ### Fixed
 - [LDAP_CLIENT] Use escape_dn_chars() instead of escape_filter_chars() in search_user() for sanitation
@@ -27,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [REDISOAUTH2SESSION] Utility function to delete an existing key and its subordinate(s)
 - [REDIS] [BASE] New scan_all() utility function to get all keys with possible matching pattern and type
 - [API_PARSER] [GSUITE] Add ipv4/ipv6 proxy support for api parser
+
 
 ## [2.0.0] - 2022-09-15
 ### Fixed

--- a/home/jails.apache/.zfs-source/home/vlt-os/scripts/pkg_upgrade.sh
+++ b/home/jails.apache/.zfs-source/home/vlt-os/scripts/pkg_upgrade.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-#Relocate Python
-/usr/local/bin/virtualenv-3.8 /home/jails.apache/.zfs-source/home/vlt-os/env
-
 if [ -f /etc/host-hostname ] ; then
     /usr/sbin/service vultured status && /bin/kill -9 $(/bin/cat /var/run/vulture/vultured.pid)
     echo "[38;5;196m! WARNING ! - Please start vultured at the end of the upgrade[0m"

--- a/home/jails.apache/.zfs-source/usr/local/etc/apache24/gui-httpd.conf
+++ b/home/jails.apache/.zfs-source/usr/local/etc/apache24/gui-httpd.conf
@@ -28,7 +28,7 @@ ScoreBoardFile /var/run/apache24.scoreboard
 WSGISocketPrefix /var/run/
 WSGIPythonHome /home/vlt-os/env
 WSGIScriptAlias / /home/vlt-os/vulture_os/vulture_os/wsgi.py
-WSGIDaemonProcess os python-path=/home/vlt-os/vulture_os:/home/vlt-os/env/lib/python3.8/site-packages
+WSGIDaemonProcess os python-path=/home/vlt-os/vulture_os:/home/vlt-os/env/lib/python*/site-packages
 WSGIProcessGroup os
 WSGIApplicationGroup %{GLOBAL}
 

--- a/home/jails.apache/.zfs-source/usr/local/etc/apache24/gui-httpd.conf
+++ b/home/jails.apache/.zfs-source/usr/local/etc/apache24/gui-httpd.conf
@@ -30,6 +30,7 @@ WSGIPythonHome /home/vlt-os/env
 WSGIScriptAlias / /home/vlt-os/vulture_os/vulture_os/wsgi.py
 WSGIDaemonProcess os python-path=/home/vlt-os/vulture_os:/home/vlt-os/env/lib/python*/site-packages
 WSGIProcessGroup os
+WSGIPassAuthorization On
 WSGIApplicationGroup %{GLOBAL}
 
 SSLSessionCache none

--- a/home/jails.apache/.zfs-source/usr/local/etc/apache24/portal-httpd.conf
+++ b/home/jails.apache/.zfs-source/usr/local/etc/apache24/portal-httpd.conf
@@ -23,7 +23,7 @@ ScoreBoardFile /var/run/apache24.scoreboard
 WSGISocketPrefix /var/run/
 WSGIPythonHome /home/vlt-os/env
 WSGIScriptAlias / /home/vlt-os/vulture_os/portal/wsgi.py
-WSGIDaemonProcess os python-path=/home/vlt-os/vulture_os:/home/vlt-os/env/lib/python3.8/site-packages
+WSGIDaemonProcess os python-path=/home/vlt-os/vulture_os:/home/vlt-os/env/lib/python*/site-packages
 WSGIProcessGroup os
 WSGIApplicationGroup %{GLOBAL}
 # Required to pass Authorization header to logon views (for OAuth2/token or Basic auth)

--- a/home/jails.apache/.zfs-source/usr/local/etc/secadm.rules
+++ b/home/jails.apache/.zfs-source/usr/local/etc/secadm.rules
@@ -1,6 +1,6 @@
 secadm {
     pax {
-        path: "/home/vlt-os/env/bin/python3.8",
+        path: "/home/vlt-os/env/bin/python3",
         mprotect: false,
         pageexec: false,
         prefer_acl: true

--- a/home/jails.portal/.zfs-source/usr/local/etc/rc.d/gunicorn
+++ b/home/jails.portal/.zfs-source/usr/local/etc/rc.d/gunicorn
@@ -21,7 +21,7 @@
 name="gunicorn"
 rcvar=gunicorn_enable
 gunicorn_group="vlt-web"
-command="/home/vlt-os/env/bin/python3.8"
+command="/home/vlt-os/env/bin/python3"
 
 : ${gunicorn_enable:="NO"}
 : ${gunicorn_pid_file:="/var/run/gunicorn.pid"}

--- a/home/jails.portal/.zfs-source/usr/local/etc/secadm.rules
+++ b/home/jails.portal/.zfs-source/usr/local/etc/secadm.rules
@@ -1,6 +1,6 @@
 secadm {
 	pax {
-		path: "/home/vlt-os/env/bin/python3.8",
+		path: "/home/vlt-os/env/bin/python3",
 		mprotect: false,
 		pageexec: false,
 		prefer_acl: true

--- a/vulture_os/authentication/idp/api.py
+++ b/vulture_os/authentication/idp/api.py
@@ -69,10 +69,21 @@ class ActionForbiddenException(Exception):
 @method_decorator(csrf_exempt, name="dispatch")
 class IDPApiView(View):
     @api_need_key("cluster_api_key")
-    def get(self, request, portal_id, repo_id):
+    def get(self, request, portal_id=None, repo_id=None, portal_name=None, repo_name=None):
         try:
-            portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo_by_id(portal, repo_id)
+            if portal_id:
+                portal = UserAuthentication.objects.get(pk=portal_id)
+            elif portal_name:
+                portal = UserAuthentication.objects.get(name=portal_name)
+            else:
+                raise ValueError("Need a portal id or name to scope token on")
+
+            if repo_id:
+                ldap_repo = get_repo_by_id(portal, repo_id)
+            elif repo_name:
+                ldap_repo = get_repo_by_name(portal, repo_name)
+            else:
+                raise ValueError("Need a repo id or name to scope token on")
 
             object_type = request.GET["object_type"].lower()
             if object_type not in ("users", "search"):
@@ -146,6 +157,12 @@ class IDPApiView(View):
                 "error": _("Invalid call")
             }, status=400)
 
+        except ValueError as e:
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=400)
+
         except UserAuthentication.DoesNotExist:
             return JsonResponse({
                 "status": False,
@@ -172,10 +189,21 @@ class IDPApiView(View):
 @method_decorator(csrf_exempt, name="dispatch")
 class IDPApiUserView(View):
     @api_need_key('cluster_api_key')
-    def post(self, request, portal_id, repo_id, action=None):
+    def post(self, request, portal_id=None, repo_id=None, portal_name=None, repo_name=None, action=None):
         try:
-            portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo_by_id(portal, repo_id)
+            if portal_id:
+                portal = UserAuthentication.objects.get(pk=portal_id)
+            elif portal_name:
+                portal = UserAuthentication.objects.get(name=portal_name)
+            else:
+                raise ValueError("Need a portal id or name to scope token on")
+
+            if repo_id:
+                ldap_repo = get_repo_by_id(portal, repo_id)
+            elif repo_name:
+                ldap_repo = get_repo_by_name(portal, repo_name)
+            else:
+                raise ValueError("Need a repo id or name to scope token on")
 
             if action and action not in ("resend_registration", "reset_password", "lock", "unlock", "reset_otp"):
                 return JsonResponse({
@@ -316,6 +344,12 @@ class IDPApiUserView(View):
                 "error": _("Invalid call")
             }, status=400)
 
+        except ValueError as e:
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=400)
+
         except NotUniqueError as e:
             return JsonResponse({
                 "status": False,
@@ -340,10 +374,21 @@ class IDPApiUserView(View):
             }, status=500)
 
     @api_need_key('cluster_api_key')
-    def put(self, request, portal_id, repo_id):
+    def put(self, request, portal_id=None, repo_id=None, portal_name=None, repo_name=None):
         try:
-            portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo_by_id(portal, repo_id)
+            if portal_id:
+                portal = UserAuthentication.objects.get(pk=portal_id)
+            elif portal_name:
+                portal = UserAuthentication.objects.get(name=portal_name)
+            else:
+                raise ValueError("Need a portal id or name to scope token on")
+
+            if repo_id:
+                ldap_repo = get_repo_by_id(portal, repo_id)
+            elif repo_name:
+                ldap_repo = get_repo_by_name(portal, repo_name)
+            else:
+                raise ValueError("Need a repo id or name to scope token on")
 
             user_dn = request.JSON['id']
 
@@ -396,6 +441,12 @@ class IDPApiUserView(View):
                 "error": _("Invalid call")
             }, status=400)
 
+        except ValueError as e:
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
+            }, status=400)
+
         except UserAuthentication.DoesNotExist:
             return JsonResponse({
                 "status": False,
@@ -413,10 +464,21 @@ class IDPApiUserView(View):
             }, status=500)
 
     @api_need_key('cluster_api_key')
-    def delete(self, request, portal_id, repo_id):
+    def delete(self, request, portal_id=None, repo_id=None, portal_name=None, repo_name=None):
         try:
-            portal = UserAuthentication.objects.get(pk=portal_id)
-            ldap_repo = get_repo_by_id(portal, repo_id)
+            if portal_id:
+                portal = UserAuthentication.objects.get(pk=portal_id)
+            elif portal_name:
+                portal = UserAuthentication.objects.get(name=portal_name)
+            else:
+                raise ValueError("Need a portal id or name to scope token on")
+
+            if repo_id:
+                ldap_repo = get_repo_by_id(portal, repo_id)
+            elif repo_name:
+                ldap_repo = get_repo_by_name(portal, repo_name)
+            else:
+                raise ValueError("Need a repo id or name to scope token on")
             redis_handler = REDISBase()
 
             user_dn = request.JSON['id']
@@ -457,6 +519,12 @@ class IDPApiUserView(View):
             return JsonResponse({
                 "status": False,
                 "error": _("Invalid call")
+            }, status=400)
+
+        except ValueError as e:
+            return JsonResponse({
+                "status": False,
+                "error": _(str(e))
             }, status=400)
 
         except UserAuthentication.DoesNotExist:

--- a/vulture_os/authentication/idp/urls.py
+++ b/vulture_os/authentication/idp/urls.py
@@ -27,11 +27,24 @@ from django.urls import path, re_path
 from authentication.idp.api import IDPApiView, IDPApiUserView, IDPApiUserTokenView, IDPApiUserTokenModificationView
 
 urlpatterns = [
+   # TODO this path is replaced by the next 2 paths, will be DEPRECATED soon
    re_path('^api/v1/authentication/idp/(?P<portal_id>[A-Fa-f0-9]+)/(?P<repo_id>[A-Fa-f0-9]+)/$', IDPApiView.as_view(), name="authentication.idp"),
+   path('api/v1/authentication/idp/<int:portal_id>/repos/<int:repo_id>/', IDPApiView.as_view(), name="authentication.idp"),
+   path('api/v1/authentication/idp/<str:portal_name>/repos/<str:repo_name>/', IDPApiView.as_view(), name="authentication.idp"),
 
+   # TODO this path is replaced by the next 2 paths, will be DEPRECATED soon
    re_path('^api/v1/authentication/idp/users/(?P<portal_id>[A-Fa-f0-9]+)/(?P<repo_id>[A-Fa-f0-9]+)/$', IDPApiUserView.as_view(), name="authentication.idp.users"),
+   path('api/v1/authentication/idp/<int:portal_id>/repos/<int:repo_id>/users/', IDPApiUserView.as_view(), name="authentication.idp.users"),
+   path('api/v1/authentication/idp/<str:portal_name>/repos/<str:repo_name>/users/', IDPApiUserView.as_view(), name="authentication.idp.users"),
 
+   # TODO this path is replaced by the next 2 paths, will be DEPRECATED soon
    path('api/v1/authentication/idp/users/<int:portal_id>/<int:repo_id>/<str:action>/',
+        IDPApiUserView.as_view(),
+        name="authentication.idp.users.action"),
+   path('api/v1/authentication/idp/<int:portal_id>/repos/<int:repo_id>/users/<str:action>/',
+        IDPApiUserView.as_view(),
+        name="authentication.idp.users.action"),
+   path('api/v1/authentication/idp/<str:portal_name>/repos/<str:repo_name>/users/<str:action>/',
         IDPApiUserView.as_view(),
         name="authentication.idp.users.action"),
 

--- a/vulture_os/authentication/user_portal/api.py
+++ b/vulture_os/authentication/user_portal/api.py
@@ -54,8 +54,8 @@ class UserPortalApi(View):
     def get(self, request, object_id=None):
         try:
             fields = request.GET.getlist('fields') or None
-            if request.GET.get('enable_external', None) :
-                enable_external = True if request.GET.get('enable_external') == "true" else False
+            enable_external = True if request.GET.get('enable_external') == "true" else False
+
             if object_id:
                 data = UserAuthentication.objects.get(pk=object_id).to_dict(fields=fields)
             elif request.GET.get('name'):

--- a/vulture_os/portal/system/authentications.py
+++ b/vulture_os/portal/system/authentications.py
@@ -206,7 +206,7 @@ class Authentication(object):
 
     def register_sso(self, backend_id):
         username = self.redis_portal_session.keys['login_' + backend_id]
-        self.oauth2_token = self.redis_portal_session.keys['oauth2_' + backend_id]
+        self.oauth2_token = self.redis_portal_session.keys.get('oauth2_' + backend_id)
         # Get current user_infos for this backend
         oauth2_scope = self.redis_portal_session.get_user_infos(backend_id)
 

--- a/vulture_os/portal/views/logon.py
+++ b/vulture_os/portal/views/logon.py
@@ -808,7 +808,9 @@ def log_in(request, workflow_id=None):
             logger.debug(f"redirect_url is {redirect_url}")
             redis_portal_session.set_redirect_url(workflow.id, redirect_url)
             # force write in redis to set expiration on session key
-            redis_portal_session.write_in_redis(workflow.authentication.auth_timeout)
+            if not redis_portal_session.exists() or workflow.authentication.enable_timeout_restart:
+                logger.error(f"refreshing session token expiration by rewriting infos")
+                redis_portal_session.write_in_redis(workflow.authentication.auth_timeout)
         else:
             # reset potentially existing redirect url to avoid wrong redirection
             redis_portal_session.del_redirect_url(workflow.id)

--- a/vulture_os/portal/views/logon.py
+++ b/vulture_os/portal/views/logon.py
@@ -547,14 +547,14 @@ def authenticate(request, workflow, portal_cookie, token_name, double_auth_only=
 
                 # If the user is already authenticated (retrieved with RedisPortalSession ) => SSO
                 else:
+                    logger.info(f"Applying SSO with connected user on backend {backend_id}")
                     portal_cookie, oauth2_token = authentication.register_sso(backend_id)
-                    logger.info("PORTAL::log_in: User {} successfully SSO-powered ! "
-                                "OAuth2 session = {}".format(authentication.credentials[0],
-                                                             authentication.redis_oauth2_session.keys))
+                    logger.info(f"PORTAL::log_in: User {authentication.credentials[0]} successfully SSO-powered !")
+                    if oauth2_token:
+                        logger.debug(f"OAuth2 session = {oauth2_token}")
 
             except AssertionError as e:
-                logger.exception(e)
-                logger.error("PORTAL::log_in: Bad captcha input for username '{}' : {}"
+                logger.exception("PORTAL::log_in: Bad captcha input for username '{}' : {}"
                              .format(authentication.credentials[0], e))
                 return authentication.ask_credentials_response(public_token=token_name, request=request, error="Bad captcha")
 
@@ -569,7 +569,7 @@ def authenticate(request, workflow, portal_cookie, token_name, double_auth_only=
                 return authentication.ask_credentials_response(public_token=token_name, request=request, error="Authentication Failure")
 
             except (DBAPIError, PyMongoError, LDAPError) as e:
-                logger.error("PORTAL::log_in: Repository driver Error while trying to authenticate user '{}' : {}"
+                logger.exception("PORTAL::log_in: Repository driver Error while trying to authenticate user '{}' : {}"
                              .format(authentication.credentials[0], e))
                 return authentication.ask_credentials_response(public_token=token_name, request=request,
                                                                error="Authentication Failure")
@@ -577,7 +577,7 @@ def authenticate(request, workflow, portal_cookie, token_name, double_auth_only=
             except (MultiValueDictKeyError, AttributeError, KeyError) as e:
                 # vltprtlsrnm is always empty during the initial redirection. Don't log that
                 if str(e) != "vltprtlsrnm":
-                    logger.error("PORTAL::log_in: Error while trying to authenticate user '{}' : {}"
+                    logger.exception("PORTAL::log_in: Error while trying to authenticate user '{}' : {}"
                                  .format(authentication.credentials[0], e))
                 return authentication.ask_credentials_response(public_token=token_name, request=request)
 

--- a/vulture_os/services/config/spoe_session.txt
+++ b/vulture_os/services/config/spoe_session.txt
@@ -22,32 +22,36 @@ spoe-agent session-agent
 
         use-backend backend_spoa_session
 
+# First choice: check for portal cookie presence
 spoe-message check-session_{{endpoint.id}}
     acl workflow_{{endpoint.id}}_host hdr(host) {{endpoint.fqdn}}
     acl workflow_{{endpoint.id}}_host hdr(host) -m beg {{endpoint.fqdn}}:
     acl workflow_{{endpoint.id}}_dir path -i -m beg {{ endpoint.public_dir }}
-    acl workflow_{{endpoint.id}}_header req.hdr(Authorization) -m found
-    acl workflow_{{endpoint.id}}_header req.hdr(X-Vlt-Token) -m found
     acl workflow_{{endpoint.id}}_cook req.cook({{ global_config.portal_cookie_name }}) -m found
     args req.cook({{ global_config.portal_cookie_name }}) str("{{endpoint.id}}") str("{{endpoint.auth_timeout}}")
-    event on-frontend-http-request if workflow_{{endpoint.id}}_host workflow_{{endpoint.id}}_dir workflow_{{endpoint.id}}_cook !workflow_{{endpoint.id}}_header
+    event on-frontend-http-request if workflow_{{endpoint.id}}_host workflow_{{endpoint.id}}_dir workflow_{{endpoint.id}}_cook
 
-spoe-message check-session_oauth_{{endpoint.id}}
-    acl workflow_{{endpoint.id}}_host hdr(host) {{endpoint.fqdn}}
-    acl workflow_{{endpoint.id}}_host hdr(host) -m beg {{endpoint.fqdn}}:
-    acl workflow_{{endpoint.id}}_dir path -i -m beg {{ endpoint.public_dir }}
-    acl workflow_{{endpoint.id}}_header req.hdr(Authorization) -m found
-    # remove Authorization type from header value (such as 'Bearer'...) and prefix with 'oauth2_' for redis querying
-    args req.hdr(Authorization),field(-1,' '),regsub('^','oauth2_') str("{{endpoint.oauth_repositories_id | join(';')}}")
-    event on-frontend-http-request if workflow_{{endpoint.id}}_host workflow_{{endpoint.id}}_dir workflow_{{endpoint.id}}_header
-
+# Second choice: if it doesn't exist, check for custom X-Vlt-Token
 spoe-message check-session_oauth_legacy_{{endpoint.id}}
     acl workflow_{{endpoint.id}}_host hdr(host) {{endpoint.fqdn}}
     acl workflow_{{endpoint.id}}_host hdr(host) -m beg {{endpoint.fqdn}}:
     acl workflow_{{endpoint.id}}_dir path -i -m beg {{ endpoint.public_dir }}
     acl workflow_{{endpoint.id}}_header req.hdr(X-Vlt-Token) -m found
+    acl workflow_{{endpoint.id}}_cook req.cook({{ global_config.portal_cookie_name }}) -m found
     # remove Authorization type from header value (such as 'Bearer'...) and prefix with 'oauth2_' for redis querying
     args req.hdr(X-Vlt-Token),field(-1,' '),regsub('^','oauth2_') str("{{endpoint.oauth_repositories_id | join(';')}}")
-    event on-frontend-http-request if workflow_{{endpoint.id}}_host workflow_{{endpoint.id}}_dir workflow_{{endpoint.id}}_header
+    event on-frontend-http-request if workflow_{{endpoint.id}}_host workflow_{{endpoint.id}}_dir workflow_{{endpoint.id}}_header !workflow_{{endpoint.id}}_cook
+
+# Final choice: if neither portal cookie nor X-Vlt-Token header are found, search for Authorization token
+spoe-message check-session_oauth_{{endpoint.id}}
+    acl workflow_{{endpoint.id}}_host hdr(host) {{endpoint.fqdn}}
+    acl workflow_{{endpoint.id}}_host hdr(host) -m beg {{endpoint.fqdn}}:
+    acl workflow_{{endpoint.id}}_dir path -i -m beg {{ endpoint.public_dir }}
+    acl workflow_{{endpoint.id}}_header req.hdr(Authorization) -m found
+    acl workflow_{{endpoint.id}}_header req.hdr(X-Vlt-Token) ! -m found
+    acl workflow_{{endpoint.id}}_cook req.cook({{ global_config.portal_cookie_name }}) -m found
+    # remove Authorization type from header value (such as 'Bearer'...) and prefix with 'oauth2_' for redis querying
+    args req.hdr(Authorization),field(-1,' '),regsub('^','oauth2_') str("{{endpoint.oauth_repositories_id | join(';')}}")
+    event on-frontend-http-request if workflow_{{endpoint.id}}_host workflow_{{endpoint.id}}_dir workflow_{{endpoint.id}}_header !workflow_{{endpoint.id}}_cook
 {% endfor %}
 

--- a/vulture_os/toolkit/api_parser/crowdstrike/crowdstrike.py
+++ b/vulture_os/toolkit/api_parser/crowdstrike/crowdstrike.py
@@ -246,17 +246,18 @@ class CrowdstrikeParser(ApiParser):
 
         self.kind = "details"
         # Default timestamp is 24 hours ago
-        since = (self.last_api_call or (timezone.now() - datetime.timedelta(days=7))).strftime("%Y-%m-%dT%H:%M:%SZ")
+        since = self.last_api_call or (timezone.now() - datetime.timedelta(days=7))
         # Get a batch of 24h at most, to avoid running the parser for too long
         to = min(timezone.now(), since + timedelta(hours=24))
         to = to.strftime("%Y-%m-%dT%H:%M:%SZ")
+        since = since.strftime("%Y-%m-%dT%H:%M:%SZ")
         tmp_logs = self.get_logs(self.kind, since=since, to=to)
-        
+
         # Downloading may take some while, so refresh token in Redis
         self.update_lock()
 
         total = len(tmp_logs)
-        
+
         if total > 0:
             logger.info(f"[{__parser__}][execute]: Total logs fetched : {total}", extra={'frontend': str(self.frontend)})
 

--- a/vulture_os/toolkit/api_parser/gsuite_alertcenter/gsuite_alertcenter.py
+++ b/vulture_os/toolkit/api_parser/gsuite_alertcenter/gsuite_alertcenter.py
@@ -141,10 +141,11 @@ class GsuiteAlertcenterParser(ApiParser):
         self.get_creds()
         self.get_http_client()
         # Default timestamp is 24 hours ago
-        since = (self.last_api_call or (timezone.now() - timedelta(days=5))).isoformat()
+        since = (self.last_api_call or (timezone.now() - timedelta(days=5)))
         # Get batches of 24h at most, to avoid running the parser for too long
         to = min(timezone.now(), since + timedelta(hours=24))
         to = to.isoformat()
+        since = since.isoformat()
         have_logs, tmp_logs = self.get_alerts(since=since, to=to)
 
         # Downloading may take some while, so refresh token in Redis

--- a/vulture_os/toolkit/api_parser/sentinel_one/sentinel_one.py
+++ b/vulture_os/toolkit/api_parser/sentinel_one/sentinel_one.py
@@ -252,7 +252,7 @@ class SentinelOneParser(ApiParser):
 
                 # Writting may take some while, so refresh token in Redis
                 self.update_lock()
-                if len(logs) > 0:
+                if len(logs) > 0 or (to - since) == timedelta(hours=24):
                     self.frontend.last_api_call = to
 
         logger.info(f"[{__parser__}]:execute: update last_api_call to {self.frontend.last_api_call}",

--- a/vulture_os/toolkit/updates/v2.1.0/0_upgrade_python.sh
+++ b/vulture_os/toolkit/updates/v2.1.0/0_upgrade_python.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ -d /zroot/apache ] ; then
+    /usr/sbin/pkg -j apache remove -y python38 ap24-py38-mod_wsgi
+    /usr/sbin/pkg -j apache install -y lang/python www/mod_wsgi4
+fi
+if [ -d /zroot/portal ] ; then
+    /usr/sbin/pkg -j portal remove -y python38 ap24-py38-mod_wsgi
+    /usr/sbin/pkg -j portal install -y lang/python www/mod_wsgi4
+fi

--- a/vulture_os/toolkit/updates/v2.1.1/0_update_apache_config.sh
+++ b/vulture_os/toolkit/updates/v2.1.1/0_update_apache_config.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -d /zroot/apache ] ; then
+    cp -r /home/jails.apache/.zfs-source/usr/local/etc/apache24/* /zroot/apache/usr/local/etc/apache24/
+    echo "[38;5;196m! WARNING ! - Please restart apache with : '/usr/sbin/jexec apache /usr/sbin/service apache24 restart'[0m"
+fi


### PR DESCRIPTION
### Fixed
- [PORTAL] [SSO] SSO could fail when portal have no oauth2 activated
- [PORTAL] Correctly refresh session timeout only when necessary
- [APACHE] [CONFIGURATION] Update Apache WSGI's configuration to allow code to read 'Authorization' header
- [API_PARSER] [SENTINEL_ONE] Avoid parser getting stuck after not having received any logs for more than 24h
- [API_PARSER] [GSUITE] Parser failure caused by wrong 'since' variable type
- [API_PARSER] [CROWDSTRIKE] Parser failure caused by wrong 'since' variable type
- [USER_PORTAL] [API] Could not get all portals through API when no ID/name was specified
- [PORTAL] Validate session Cookies, then Vulture Headers, then 'Authorization' Header during session validation
   - Allows protected applications to use 'Authorization' Headers when a user browses it with a web session

### Added
- [UPGRADE] Added bash script to uninstall python 3.8 and install generic python in apache and portal jail
- [IDP_USERS] Support for new API paths
  - Added paths for uniformization with new /tokens endpoints
  - Ability to use portal/repo names in queries

### Changed
- [PORTAL] [LOGGING] Improved logging and details in case of errors
- [DEPENDENCY] Changed uses of python 3.8 to generic python3 to use the default python version for the system (ie python 3.8 for HBSD12 and 3.9 for HBSD13)

### Removed
- [PKG_UPGRADE] Don't rebuild python env using `virtualenv`, binaries are no longer symlinked