### PR TITLE
API_PARSER :: Crowdstrike : Fix last_api_call stagnation

### DIFF
--- a/vulture_os/toolkit/api_parser/crowdstrike/crowdstrike.py
+++ b/vulture_os/toolkit/api_parser/crowdstrike/crowdstrike.py
@@ -264,6 +264,11 @@ class CrowdstrikeParser(ApiParser):
             # Logs sorted by timestamp descending, so first is newer
             self.frontend.last_api_call = to
 
+        elif self.last_api_call < timezone.now()-timedelta(hours=24):
+            # If no logs where retrieved during the last 24hours,
+            # move forward 1h to prevent stagnate ad vitam eternam
+            self.last_api_call += timedelta(hours=1)
+
         self.write_to_file([self.format_log(l) for l in tmp_logs])
 
         # Writting may take some while, so refresh token in Redis


### PR DESCRIPTION
### Fixed
 - [API_PARSER][Crowdstrike] Prevent last_api_call stagnation if no events where retrieved during the last 24h
