### PR TITLE
Fix crowdstrike api

### DIFF
--- a/vulture_os/toolkit/api_parser/crowdstrike/crowdstrike.py
+++ b/vulture_os/toolkit/api_parser/crowdstrike/crowdstrike.py
@@ -238,6 +238,7 @@ class CrowdstrikeParser(ApiParser):
     def format_log(self, log):
         log['kind'] = self.kind
         log['observer_version'] = self.observer_version
+        log['url'] = self.api_host
         return json.dumps(log)
 
     def execute(self):


### PR DESCRIPTION
Fix: Add api_host to 'url' event log field