### PR TITLE
FIX::TLS:Modifying a profile update frontend and backend config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- [TLS] Once the TLS profile form is received, all Listners and Applications are scanned to verify if the profile is related to them and reload the config files when needed to match the update.
+- [FRONTEND] [GUI] When selecting plain text for a frontend, it is handled as http
+### Changed
+- [GUI] [TLS] It's now impossible to delete a TLS profile used in a frontend or a backend (will list where it is used)
+
+
 ## [2.2.1] - 2022-12-13
 ### Fixed
 - [GUNICORN] [CONF] Timeout increased to 60 seconds

--- a/vulture_os/applications/backend/models.py
+++ b/vulture_os/applications/backend/models.py
@@ -575,7 +575,7 @@ class Server(models.Model):
         TLSProfile,
         null=True,
         default="",
-        on_delete=models.SET_DEFAULT
+        on_delete=models.PROTECT
     )
     """ Weight of the server """
     weight = models.PositiveIntegerField(

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -1816,8 +1816,9 @@ class Listener(models.Model):
     """ TLSProfile to use when listening """
     tls_profiles = models.ArrayReferenceField(
         TLSProfile,
+        null=True,
         default=[],
-        on_delete=models.SET_DEFAULT
+        on_delete=models.PROTECT
     )
     """ List of ip to allow traffic from, or 'any' """
     whitelist_ips = models.TextField(

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -354,6 +354,10 @@ def frontend_edit(request, object_id=None, api=False):
 
                 """ And instantiate form with the object, or None """
                 listener_f = ListenerForm(listener, instance=instance_l)
+                
+                if listener_f.data.get('tls_profiles') == ['']:
+                    listener_f.data['tls_profiles'] = None
+
                 if not listener_f.is_valid():
                     form.add_error("listeners", listener_f.errors.as_json() if api else [error for error_list in listener_f.errors.as_data().values() for error in error_list])
 

--- a/vulture_os/system/pki/views.py
+++ b/vulture_os/system/pki/views.py
@@ -259,6 +259,37 @@ def tls_profile_edit(request, object_id=None, api=False):
             tls_profile.save_conf()
             logger.info("TLSProfile '{}' write on disk requested.".format(tls_profile.name))
 
+            from system.cluster.models import Cluster
+            from services.frontend.models import Frontend
+
+            node = Cluster.get_current_node()
+            if not node:
+                print("Current node not found. Maybe the cluster has not been initiated yet.")
+            else:
+                try:
+                    for frontend in Frontend.objects.filter(mode="http"):
+                        for listener in frontend.listener_set.all():
+                            for tlsprofile in listener.tls_profiles.all():
+                                # Compare tls profiles between the listener and the form
+                                if tlsprofile != None and tlsprofile.name == tls_profile.name:
+                                    logger.info(f"Frontend {frontend} conf reload asked")
+                                    #frontend.reload_conf()
+                                    frontend.reload_haproxy_conf()
+                                    logger.info("Frontend confs reloaded")
+
+                        for backend in frontend.backend.all():
+                            for server in backend.server_set.all():
+                                # Compare tls profile between the server and the form
+                                if server.tls_profile != None and server.tls_profile.name == tls_profile.name:
+                                    logger.info(f"Backend {backend} conf reload asked")
+                                    backend.reload_conf()
+                                    logger.info("Backend confs reloaded")
+
+                    node.api_request("services.haproxy.haproxy.restart_service")
+
+                except Exception as e:
+                    logger.info(f"Failed to update TLS profiles configurations: {e}")
+
         except VultureSystemConfigError as e:
             """ If we get here, problem occurred during save_conf, after save """
             if first_save:

--- a/vulture_os/system/pki/views.py
+++ b/vulture_os/system/pki/views.py
@@ -262,23 +262,16 @@ def tls_profile_edit(request, object_id=None, api=False):
             tls_profile.save_conf()
             logger.info("TLSProfile '{}' write on disk requested.".format(tls_profile.name))
 
-            node = Cluster.get_current_node()
-            if not node:
-                logger.error("Current node not found. Maybe the cluster has not been initiated yet.")
-            else:
-                try:
-                    for frontend in set(listener.frontend for listener in tls_profile.listener_set.all()):
-                        frontend.reload_haproxy_conf()
-                        logger.info("Frontend confs reloaded")
+            for frontend in set(listener.frontend for listener in tls_profile.listener_set.all()):
+                frontend.reload_haproxy_conf()
+                logger.info("Frontend confs reloaded")
 
-                    for backend in set(server.backend for server in tls_profile.server_set.all()):
-                        backend.reload_conf()
-                        logger.info("Backend confs reloaded")
+            for backend in set(server.backend for server in tls_profile.server_set.all()):
+                backend.reload_conf()
+                logger.info("Backend confs reloaded")
 
-                    node.api_request("services.haproxy.haproxy.restart_service")
-
-                except Exception as e:
-                    logger.error(f"Failed to update TLS profiles configurations: {e}")
+            if tls_profile.server_set.exists():
+                Cluster.api_request("services.haproxy.haproxy.reload_service")
 
         except VultureSystemConfigError as e:
             """ If we get here, problem occurred during save_conf, after save """


### PR DESCRIPTION
### Changed
- Once the TLS profile form is received, all Listners and Applications are scanned to verify if the profile is related to them and reload the config files when needed to match the update.
- It is now impossible to delete a TLS profile used in a frontend or a backend
- The delete template will list all the listeners who use the TLS profile
- When selecting plain text for a frontend, it is handled as http