### PR TITLE
[API_PARSER][Imperva] Prevent downloading same files

### DIFF
--- a/vulture_os/toolkit/api_parser/imperva/imperva.py
+++ b/vulture_os/toolkit/api_parser/imperva/imperva.py
@@ -204,22 +204,28 @@ class ImpervaParser(ApiParser):
                     except Exception as e:
                         logger.exception(f"[{__parser__}]:execute: {e}", extra={'frontend': str(self.frontend)})
 
-                        # Download log files index
-                        log_files = self._download_log_index()
-                        first_log_id_in_index = int(log_files[0].split('.')[0].split('_')[1])
-                        if next_log_index < first_log_id_in_index:
-                            msg = f"Current downloaded file is not in the index file any more. This is probably due to a long delay in downloading. Attempting to recover"
-                            logger.error(f"[{__parser__}]:execute: {msg}", extra={'frontend': str(self.frontend)})
-
-                            self.imperva_last_log_file = ""
-                        elif f"{self.imperva_last_log_file.split('_')[0]}_{next_log_index+1}.log" in log_files:
-                            msg = f"Skipping file {next_log_file}"
-                            logger.warning(f"[{__parser__}]:execute: {msg}", extra={'frontend': str(self.frontend)})
-                            self.imperva_last_log_file = next_log_file
+                        try:
+                            # Download log files index
+                            log_files = self._download_log_index()
+                        except Exception as e:
+                            logger.exception(f"[{__parser__}]:execute: Cannot download log index ! Details : {e}", extra={'frontend': str(self.frontend)})
+                            break
                         else:
-                            msg = f"Next file {next_log_file} still does not exist."
-                            logger.info(f"[{__parser__}]:execute: {msg}", extra={'frontend': str(self.frontend)})
-                        break
+                            first_log_id_in_index = int(log_files[0].split('.')[0].split('_')[1])
+                            if next_log_index < first_log_id_in_index:
+                                msg = f"Current downloaded file is not in the index file any more. This is probably due to a long delay in downloading. Attempting to recover"
+                                logger.error(f"[{__parser__}]:execute: {msg}", extra={'frontend': str(self.frontend)})
+
+                                self.imperva_last_log_file = ""
+                            elif f"{self.imperva_last_log_file.split('_')[0]}_{next_log_index+1}.log" in log_files:
+                                msg = f"Skipping file {next_log_file}"
+                                logger.warning(f"[{__parser__}]:execute: {msg}", extra={'frontend': str(self.frontend)})
+                                self.imperva_last_log_file = next_log_file
+                            else:
+                                msg = f"Next file {next_log_file} still does not exist."
+                                logger.info(f"[{__parser__}]:execute: {msg}", extra={'frontend': str(self.frontend)})
+                            break
+
 
             self.frontend.imperva_last_log_file = self.imperva_last_log_file
             self.frontend.last_api_call = self.last_api_call


### PR DESCRIPTION
### Fixed
 - [API_PARSER][IMPERVA] Prevent infinite download loop when logs index cannot be downloaded - last_log_file where never set due to missing try/except
