### PR TITLE
API_NETSKOPE::fix infinite loop when there is no log

### DIFF
--- a/vulture_os/toolkit/api_parser/netskope/netskope.py
+++ b/vulture_os/toolkit/api_parser/netskope/netskope.py
@@ -129,6 +129,9 @@ class NetskopeParser(ApiParser):
             self.update_lock()
 
             logs = response['result']
+            if len(logs) == 0:
+                self.frontend.last_api_call = to
+                break
             offset += len(logs)
 
             self.write_to_file([self.parse_log(l) for l in logs])

--- a/vulture_os/toolkit/api_parser/netskope/netskope.py
+++ b/vulture_os/toolkit/api_parser/netskope/netskope.py
@@ -130,7 +130,6 @@ class NetskopeParser(ApiParser):
 
             logs = response['result']
             if len(logs) == 0:
-                self.frontend.last_api_call = to
                 break
             offset += len(logs)
 

--- a/vulture_os/toolkit/api_parser/netskope/netskope.py
+++ b/vulture_os/toolkit/api_parser/netskope/netskope.py
@@ -130,6 +130,8 @@ class NetskopeParser(ApiParser):
 
             logs = response['result']
             if len(logs) == 0:
+                logger.info(f"[{__parser__}][execute]: No more log to fetch. End of the parsing",
+                            extra={'frontend': str(self.frontend)})
                 break
             offset += len(logs)
 


### PR DESCRIPTION
[API_NETSKOPE] Break the loop of the logs request when there is no logs