### PR TITLE
[API_PARSER] WAF_CLOUD_PROTECTOR Limit execution in time

### DIFF
--- a/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
+++ b/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
@@ -320,6 +320,8 @@ class WAFCloudProtectorParser(ApiParser):
                     self.write_to_file(json_lines)
                     # And update lock after sending lines to Rsyslog
                     self.update_lock()
+                    if to.hour == 23 and to.minute == 59 and to.second == 59:
+                        to = to + timedelta(seconds=1)
                     self.frontend.waf_cloud_protector_timestamps[log_type][server] = to
                     self.frontend.save()
 

--- a/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
+++ b/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
@@ -267,7 +267,7 @@ class WAFCloudProtectorParser(ApiParser):
                     # datetime.now() : because we don't have timezone in the timestamp in mongodb (not supported by mongo)
                     since = timezone.make_aware(self.frontend.waf_cloud_protector_timestamps[log_type].get(server) or (datetime.now() - timedelta(days=2)))
 
-                    # Calculate the time before since to end of the day of since
+                    # Calculate the time between since to end of the day of since
                     since_diff_hour = 23 - since.hour
                     since_diff_minute = 59 - since.minute
                     since_diff_second = 59 - since.second

--- a/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
+++ b/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
@@ -255,7 +255,8 @@ class WAFCloudProtectorParser(ApiParser):
     def execute(self):
 
         # LIMIT TO 6 EXECUTION PER HOUR
-        if timezone.now() % 10 != 0:
+        if (timezone.now() % 10) != 0:            
+            logger.info(f"[{__parser__}]:execute: Parsing bypassed, latest was too reccently ", extra={'frontend': str(self.frontend)})
             return
 
         for server in self.waf_cloud_protector_servers.split(','):

--- a/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
+++ b/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
@@ -266,7 +266,15 @@ class WAFCloudProtectorParser(ApiParser):
                     ## GET LOGS ##
                     # datetime.now() : because we don't have timezone in the timestamp in mongodb (not supported by mongo)
                     since = timezone.make_aware(self.frontend.waf_cloud_protector_timestamps[log_type].get(server) or (datetime.now() - timedelta(days=2)))
-                    to = min(timezone.now(), since + timedelta(hours=24))
+
+                    # Calculate the time before since to end of the day of since
+                    since_diff_hour = 23 - since.hour
+                    since_diff_minute = 59 - since.minute
+                    since_diff_second = 59 - since.second
+
+                    # The difference between since and to is : MIN 00h00m00s and MAX 23h59m59s
+                    to = min(timezone.now(), since + timedelta(hours=since_diff_hour, minutes=since_diff_minute, seconds=since_diff_second))
+
                     delta = ((to - since) + timedelta(days=1)).days
 
                     logger.info(f"[{__parser__}]: get_logs from {server} of type {log_type} since {since} to {to}", extra={'frontend': str(self.frontend)})

--- a/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
+++ b/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
@@ -320,6 +320,8 @@ class WAFCloudProtectorParser(ApiParser):
                     self.write_to_file(json_lines)
                     # And update lock after sending lines to Rsyslog
                     self.update_lock()
+
+                    # There is no microsecond, add 1 second to go the next day
                     if to.hour == 23 and to.minute == 59 and to.second == 59:
                         to = to + timedelta(seconds=1)
                     self.frontend.waf_cloud_protector_timestamps[log_type][server] = to

--- a/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
+++ b/vulture_os/toolkit/api_parser/waf_cloud_protector/waf_cloud_protector.py
@@ -254,6 +254,10 @@ class WAFCloudProtectorParser(ApiParser):
 
     def execute(self):
 
+        # LIMIT TO 6 EXECUTION PER HOUR
+        if timezone.now() % 10 != 0:
+            return
+
         for server in self.waf_cloud_protector_servers.split(','):
             for log_type in ['alert', 'traffic']:
                 try:


### PR DESCRIPTION
FIX WAF_CLOUD_PROTECTOR : Limit to execution in time, because too expensive in cpu & ram, and not necessary 