### PR TITLE
COOKIES: ensure cookies' security is preserved

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PKG_UPGRADE] Avoid trying to launch upgrade scripts when node is not bootstrapped
 - [GUI] [ACLS] Improve 'Used by' presentation of Wokrflows using ACLs
 - [CODE] [CLEAN] Minor corrections
+- [SSO_CLIENT] [COOKIES] Fix cookies' banning when receiving application's response
 
 
 ## [2.10.2] - 2023-09-25

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [CODE] [CLEAN] Minor corrections
 - [SSO_CLIENT] [COOKIES] Fix cookies' banning when receiving application's response
 - [SSO_CLIENT] [COOKIES] Correctly check the 'HttpOnly' attribute set from application's response
+- [IDP] [COOKIES] Ensure 'HttpOnly' attribute is always set on IDP session cookies
 
 
 ## [2.10.2] - 2023-09-25

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GUI] [ACLS] Improve 'Used by' presentation of Wokrflows using ACLs
 - [CODE] [CLEAN] Minor corrections
 - [SSO_CLIENT] [COOKIES] Fix cookies' banning when receiving application's response
+- [SSO_CLIENT] [COOKIES] Correctly check the 'HttpOnly' attribute set from application's response
 
 
 ## [2.10.2] - 2023-09-25

--- a/vulture_os/portal/system/sso_clients.py
+++ b/vulture_os/portal/system/sso_clients.py
@@ -162,7 +162,7 @@ class SSOClient(object):
                 final_response[key] = item
 
         for cookie in self.session.cookies:
-            if key not in self.banned_cookies:
+            if cookie.name not in self.banned_cookies:
                 final_response = self.add_cookie_W_path(final_response, cookie, app_uri)
 
         return final_response

--- a/vulture_os/portal/system/sso_clients.py
+++ b/vulture_os/portal/system/sso_clients.py
@@ -147,7 +147,8 @@ class SSOClient(object):
         response.set_cookie(cookie.name,
                             cookie.value,
                             path=path,
-                            httponly=cookie._rest.get('HttpOnly', False),
+                            # NEEDS to check if key is PRESENT: value will be set to None when attribute is set for cookie!
+                            httponly=cookie.has_nonstandard_attr('HttpOnly'),
                             secure=portal_url.startswith('https'),
                             max_age=cookie.expires,
                             samesite=cookie.get_nonstandard_attr('SameSite', 'Lax'))

--- a/vulture_os/portal/views/logon.py
+++ b/vulture_os/portal/views/logon.py
@@ -144,7 +144,7 @@ def openid_start(request, workflow_id, repo_id):
         response = HttpResponseRedirect(authorization_url)
         # Needed for Safari and mobiles support
         response['Content-Length'] = 0
-        response.set_cookie(portal_cookie_name, portal_cookie, domain=split_domain(fqdn), httponly=False, secure=scheme=="https")
+        response.set_cookie(portal_cookie_name, portal_cookie, domain=split_domain(fqdn), httponly=True, secure=scheme=="https")
 
         return response
 


### PR DESCRIPTION
## Fixed
- [SSO_CLIENT] [COOKIES] Fix cookies' banning when receiving application's response
- [SSO_CLIENT] [COOKIES] Correctly check the 'HttpOnly' attribute set from application's response
- [IDP] [COOKIES] Ensure 'HttpOnly' attribute is always set on IDP session cookies