### PR TITLE
[MS_SENTINEL] Evol to use new alert_time as outdated alert check & fix entities gathering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+- [API_PARSER] [MS_SENTINEL] timeGenerated -> processingEndTime and incident.id -> incident.name
 ### Fixed
 - [PORTAL] [IDP] Refresh token validation with multiple IDP
 - [FRONTEND] Disable log condition if log forwarder disabled


### PR DESCRIPTION
### Added
   - [**MS_SENTINEL**]
      + **Not intended changes** Fix **entities** gathering using `incident.entities` rather than `incident.value` as source dictionary field and use `incident.name` instead of incident.id to fetch content from API
      + Evol to use `properties.processingEndTime` instead of `properties.timeGenerated` to determine if alert is an outdated one