### PR TITLE
[NOZOMI_PROBE]: Fix invalid timestamp in query

### DIFF
--- a/vulture_os/toolkit/api_parser/nozomi_probe/nozomi_probe.py
+++ b/vulture_os/toolkit/api_parser/nozomi_probe/nozomi_probe.py
@@ -84,7 +84,7 @@ class NozomiProbeParser(ApiParser):
 
     def get_logs(self, since=None):
         if isinstance(since, datetime):
-            since = since.timestamp()*1000
+            since = int(since.timestamp()*1000)
 
         self._connect()
 


### PR DESCRIPTION
### Fixed
 - [COLLECTOR][NOZOMI_PROBE] API requires timestamp as integer, not as float.