### PR TITLE
[FRONTEND] Allow skipping unresponsive nodes during HAProxy test_conf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Unreleased
+### Fixed
+- [FRONTEND] Allow skipping unresponsive nodes during HAProxy test_conf
 
 
 ## [2.14.2] - Unreleased

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -1546,10 +1546,11 @@ class Frontend(models.Model):
                 # Node may be unavailable for the moment
                 # Changes will be synced if node is up within 30 days
                 logger.error(e)
-                logger.warning(f"on node '{node_name}'\n Request failure.", "haproxy")
-            if not infos.get('status'):
-                raise ServiceTestConfigError(f"on node '{node_name}'\n{infos.get('error')}", "haproxy",
-                                             traceback=infos.get('error_details'))
+                logger.warning(f"on node '{node_name}'\n Request failure.")
+            else:
+                if infos.get('status'):
+                    raise ServiceTestConfigError(f"on node '{node_name}'\n{infos.get('error')}", "haproxy",
+                                                traceback=infos.get('error_details'))
         else:
             # Replace name of frontend to prevent duplicate frontend while testing conf
             test_haproxy_conf(test_filename,

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -1538,15 +1538,17 @@ class Frontend(models.Model):
             try:
                 global_config = Cluster().get_global_config()
                 cluster_api_key = global_config.cluster_api_key
-                infos = post("https://{}:8000/api/services/frontend/test_conf/".format(node_name),
+                infos = post(f"https://{node_name}:8000/api/services/frontend/test_conf/",
                              headers={'cluster-api-key': cluster_api_key},
                              data={'conf': test_conf, 'filename': test_filename, 'disabled': not self.enabled},
-                             verify=False, timeout=30).json()
+                             verify=X509Certificate.objects.get(pk=1).ca_filename(), timeout=30).json()
             except Exception as e:
+                # Node may be unavailable for the moment
+                # Changes will be synced if node is up within 30 days
                 logger.error(e)
-                raise ServiceTestConfigError("on node '{}'\n Request failure.".format(node_name), "haproxy")
+                logger.warning(f"on node '{node_name}'\n Request failure.", "haproxy")
             if not infos.get('status'):
-                raise ServiceTestConfigError("on node '{}'\n{}".format(node_name, infos.get('error')), "haproxy",
+                raise ServiceTestConfigError(f"on node '{node_name}'\n{infos.get('error')}", "haproxy",
                                              traceback=infos.get('error_details'))
         else:
             # Replace name of frontend to prevent duplicate frontend while testing conf

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -1536,21 +1536,19 @@ class Frontend(models.Model):
                 test_conf = test_conf.replace(f"backend Workflow_{workflow.pk}", f"backend {uuid4()}")
         if node_name != Cluster.get_current_node().name:
             try:
-                global_config = Cluster().get_global_config()
-                cluster_api_key = global_config.cluster_api_key
+                cluster_api_key = Cluster().get_global_config().cluster_api_key
                 infos = post(f"https://{node_name}:8000/api/services/frontend/test_conf/",
                              headers={'cluster-api-key': cluster_api_key},
                              data={'conf': test_conf, 'filename': test_filename, 'disabled': not self.enabled},
-                             verify=X509Certificate.objects.get(pk=1).ca_filename(), timeout=30).json()
+                             verify=X509Certificate.objects.get(name=node_name).ca_filename(), timeout=30).json()
             except Exception as e:
                 # Node may be unavailable for the moment
                 # Changes will be synced if node is up within 30 days
                 logger.error(e)
-                logger.warning(f"on node '{node_name}'\n Request failure.")
-            else:
-                if infos.get('status'):
-                    raise ServiceTestConfigError(f"on node '{node_name}'\n{infos.get('error')}", "haproxy",
-                                                traceback=infos.get('error_details'))
+                raise ServiceTestConfigError("on node '{}'\n Request failure.".format(node_name), "haproxy")
+            if not infos.get('status'):
+                raise ServiceTestConfigError(f"on node '{node_name}'\n{infos.get('error')}", "haproxy",
+                                            traceback=infos.get('error_details'))
         else:
             # Replace name of frontend to prevent duplicate frontend while testing conf
             test_haproxy_conf(test_filename,

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -451,11 +451,11 @@ def frontend_edit(request, object_id=None, api=False):
                     frontend.configuration[node.name] = frontend.generate_conf(listener_list=listeners,
                                                                            header_list=header_objs,
                                                                            node=node)
-                    frontend.test_conf(node.name)
                     if node.state == "UP":
+                        frontend.test_conf(node.name)
                         logger.info(f"FRONTEND::Edit: Configuration test ok on node {node.name}")
                     else:
-                        logger.warning(f"FRONTEND::Edit: Configuration test skipped on node {node.name}")
+                        logger.warning(f"FRONTEND::Edit: Configuration test skipped on node {node.name} (state {node.state})")
         except ServiceError as e:
             logger.exception(e)
             return render_form(frontend, save_error=[str(e), e.traceback])

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -452,7 +452,10 @@ def frontend_edit(request, object_id=None, api=False):
                                                                            header_list=header_objs,
                                                                            node=node)
                     frontend.test_conf(node.name)
-                    logger.info(f"FRONTEND::Edit: Configuration test ok on node {node.name}")
+                    if node.state == "UP":
+                        logger.info(f"FRONTEND::Edit: Configuration test ok on node {node.name}")
+                    else:
+                        logger.warning(f"FRONTEND::Edit: Configuration test skipped on node {node.name}")
         except ServiceError as e:
             logger.exception(e)
             return render_form(frontend, save_error=[str(e), e.traceback])


### PR DESCRIPTION
### Fixed
- [FRONTEND] Allow skipping unresponsive nodes during HAProxy test_conf