### PR TITLE
[API_TRENDMICRO_VISIONONE] Various fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [REPUTATION_CTX] Ensure internally defined DBs cannot be modified
 - [SYSTEM] [PKI] Fix wrong ca.key after cluster_join
 - [API_PARSER] Connect automatically to redis matser
+- [API_PARSER] [TRENDMICRO_VISIONONE] Correctly handle errors in log fetches
+- [API_PARSER] [TRENDMICRO_VISIONONE] Avoid 429 errors by increasing default pagination
+- [API_PARSER] [TRENDMICRO_VISIONONE] Delay log fetching by 5 minutes to be sure to get all logs
 
 
 ## [2.14.2] - 2024-02-19


### PR DESCRIPTION
- Add `status` in execute_query() to not insert in rsyslog/update timestamp if we've encountered an error while gathering logs
- Raise pagination limit on alerts and audits logs from `50` to `200` and `5000` to oat logs to reduce requests count
- Update gathering range from `1 day` to `1 minute`, causing extremely long querying in `while true` to browse all pages - triggering `429 Too Many Requests` (rate-limit) while restarting from a long time
- Delay gathering using `while to <= timezone.now() - timedelta(minutes=5): do get_logs()` because API doesn't serve all logs at real-time (another solution would be to use parameter ingestedStartDateTime & ingestedEndDateTime for querying log in the last hour range only, and detectedStartDateTime & detectedEndDateTime for more olders)