### PR TITLE
API_PARSER::FIXED: custom parser certificate deselection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [FRONTEND] Missing redis fields in template infos
 - [API_PARSER] [HARFANGLAB] Increase the limit of logs in request and reduce time range of requests
 - [API_PARSER] [CSC_DOMAINMANAGER] Split logs with several records
+- [API_PARSER] Correctly select custom parser certificate when set
 
 
 ## [2.15.3] - 2024-04-24

--- a/vulture_os/services/frontend/views.py
+++ b/vulture_os/services/frontend/views.py
@@ -38,7 +38,6 @@ from gui.forms.form_utils import DivErrorList
 from services.frontend.form import FrontendForm, ListenerForm, LogOMTableForm, FrontendReputationContextForm
 from services.frontend.models import Frontend, FrontendReputationContext, Listener, FILEBEAT_LISTENING_MODE, FILEBEAT_MODULE_LIST, FILEBEAT_MODULE_CONFIG
 from system.cluster.models import Cluster, Node
-from system.pki.models import X509Certificate
 from toolkit.api.responses import build_response, build_form_errors
 from toolkit.http.headers import HeaderForm, DEFAULT_FRONTEND_HEADERS
 from toolkit.api_parser.utils import get_api_parser
@@ -704,9 +703,6 @@ def frontend_test_apiparser(request):
                 v = v == "true"
 
             data[k] = v
-
-        if data.get('api_parser_verify_ssl', True) and data.get('api_parser_custom_certificate', None):
-            data['api_parser_custom_certificate'] = X509Certificate.objects.get(pk=data['api_parser_custom_certificate']).bundle_filename
 
         if data.get('api_parser_use_proxy', True) and data.get('api_parser_custom_proxy', None):
             # parse_proxy_url will validate and return a correct url

--- a/vulture_os/toolkit/api_parser/api_parser.py
+++ b/vulture_os/toolkit/api_parser/api_parser.py
@@ -33,6 +33,7 @@ from redis import ReadOnlyError
 from django.conf import settings
 from services.frontend.models import Frontend
 from system.config.models import Config
+from system.pki.models import X509Certificate
 from toolkit.network.network import get_proxy
 from toolkit.redis.redis_base import RedisBase
 from toolkit.network.network import JAIL_ADDRESSES
@@ -49,8 +50,11 @@ class ApiParser:
     def __init__(self, data):
         self.data = data
 
-        self.api_parser_verify_ssl = data.get("api_parser_verify_ssl", True)
-        self.api_parser_custom_certificate = data.get("api_parser_custom_certificate", None)
+        self.api_parser_verify_ssl = self.data.get("api_parser_verify_ssl", True)
+        if self.api_parser_verify_ssl and self.data.get("api_parser_custom_certificate", None):
+            self.api_parser_custom_certificate = X509Certificate.objects.get(pk=self.data["api_parser_custom_certificate"]).bundle_filename
+        else:
+            self.api_parser_custom_certificate = None
 
         if current_thread() is main_thread():
             signal.signal(signal.SIGINT, self._handle_stop)


### PR DESCRIPTION
### Fixed
- [API_PARSER] Wrongly select custom parser certificate when verification is disabled