### PR TITLE
[API_PARSER][GATEWATCHER_ALERTS] Avoid missing logs by setting the last_api_call the timestamp of the last retrieved log

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - [API_PARSER] [CROWDSTRIKE] Allow to disable fetching of 'incident' logs
+### Fixed
 - [API_PARSER] [GATEWATCHER_ALERTS] Avoid missing logs by setting the last_api_call the timestamp of the last retrieved log
 
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - [API_PARSER] [CROWDSTRIKE] Allow to disable fetching of 'incident' logs
+- [API_PARSER] [GATEWATCHER_ALERTS] Avoid missing logs by setting the last_api_call the timestamp of the last retrieved log
 
 
 ## [2.15.6] - 2024-07-12

--- a/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
+++ b/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
@@ -98,6 +98,7 @@ class GatewatcherAlertsParser(ApiParser):
         page = 1
         while(nb_logs < count):
             query['page'] = page
+            logger.debug(f"{[__parser__]}:get_logs: params for request are '{query}'", extra={'frontend': str(self.frontend)})
             page += 1
             alerts = self.execute_query(alert_url, params=query)
             count = int(alerts["count"])
@@ -144,7 +145,7 @@ class GatewatcherAlertsParser(ApiParser):
         self.update_lock()
         # increment by 1ms to avoid duplication of logs
         if logs:
-            self.frontend.last_api_call = datetime.fromisoformat(logs[-1]["alert"]["date"].replace("Z", "+00:00")) + timedelta(microseconds=1)
+            self.frontend.last_api_call = datetime.fromisoformat(logs[-1]["alert"]["date"].replace("Z", "+00:00")) + timedelta(milliseconds=1)
             self.frontend.save()
 
         logger.info(f"[{__parser__}]:execute: Parsing done.", extra={'frontend': str(self.frontend)})

--- a/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
+++ b/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
@@ -85,7 +85,10 @@ class GatewatcherAlertsParser(ApiParser):
     def get_logs(self, since, to):
         self._connect()
         alert_url = f"https://{self.gatewatcher_alerts_host}{self.ALERTS_ENDPOINT}"
-        raw_alert_url = f"https://{self.gatewatcher_alerts_host}{self.ALERTS_ENDPOINT}"
+        if isinstance(since, datetime):
+            since = since.isoformat()
+        if isinstance(to, datetime):
+            to = to.isoformat()
         query = {
             'date_from': since,
             'date_to': to,


### PR DESCRIPTION

### Fixed

 - [API_PARSER][GATEWATCHER_ALERTS] Avoid missing logs by setting the last_api_call the timestamp of the last retrieved log

