### PR TITLE
[API_HARFANGLAB] Hotfix to add a check when powershell_command is None

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- [API_PARSER] [HARFANGLAB] Hotfix to add a check when powershell_command object is None
 
 
 ## [2.15.8] - 2024-07-24

--- a/vulture_os/toolkit/api_parser/harfanglab/harfanglab.py
+++ b/vulture_os/toolkit/api_parser/harfanglab/harfanglab.py
@@ -192,14 +192,14 @@ class HarfangLabParser(ApiParser):
         log['is_frombase64string'] = False
 
         details_powershell = log.get('details_powershell', None)
-        if details_powershell:
-            powershell_command = log.get('PowershellCommand', None)
-
-            if "FromBase64String" in powershell_command:
-                log['is_frombase64string'] = True
-            if len(powershell_command) >= 16384:
-                log['details_powershell']['PowershellCommand'] = powershell_command[:16384]
-                log['is_truncated_powershell'] = True
+        if details_powershell and isinstance(details_powershell, dict):
+            powershell_command = details_powershell.get('PowershellCommand', None)
+            if powershell_command and isinstance(powershell_command, str):
+                if len(powershell_command) >= 16384:
+                    log['details_powershell']['PowershellCommand'] = powershell_command[:16384]
+                    log['is_truncated_powershell'] = True
+                if "FromBase64String" in powershell_command:
+                    log['is_frombase64string'] = True
 
         return json.dumps(log)
 


### PR DESCRIPTION
### Fixed
- [API_PARSER] [HARFANGLAB] Hotfix to add a check when powershell_command object is None