### PR TITLE
[API_PARSER] [GATEWATCHER_ALERTS] Delayed logs gathering by 5 minutes to avoid malware's alerts being not inserted by API when we're making our request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.15.10]
 ### Fixed
 - [API_PARSER] [NOZOMI_PROBE] Update timestamp when no logs received during last 24h
+- [API_PARSER] [GATEWATCHER_ALERTS] Delayed logs gathering by 5 minutes to avoid alerts being not inserted in API when we're making our request
 
 
 ## [2.15.9] - 2024-07-25

--- a/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
+++ b/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
@@ -146,10 +146,9 @@ class GatewatcherAlertsParser(ApiParser):
         self.write_to_file([self.format_log(log) for log in logs])
         self.update_lock()
 
-
         if logs: # increment by 1ms to avoid duplication of logs
             self.frontend.last_api_call = (datetime.fromisoformat(logs[-1]["alert"]["date"].replace("Z", "+00:00")) + timedelta(milliseconds=1))
-        elif len(logs) == 0 and to == since + timedelta(hours=24): # if no logs during last 24h
+        elif to == since + timedelta(hours=24): # if no logs during last 24h
             self.frontend.last_api_call += timedelta(hours=23, minutes=59)
         self.frontend.save()
 


### PR DESCRIPTION
### Fixed
 - [API_PARSER] [GATEWATCHER_ALERTS]
   * Delayed logs gathering by 5 minutes to avoid malware's alerts being not inserted by API when we're making our request
   * Add security when we don't collect logs over period of 24h