### PR TITLE
[API_PARSER] [CYBEREASON] Various hotfixes causing doublon and/or missing logs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [NETWORK] [GUI] Prevent missing interfaces in selection when refreshing interfaces on a cluster
 - [GUI] Wrong date formatting in the task list
 - [GUI] [PF] Correctly validate and return errors when changing custom PF rules
+- [API_PARSER] [CYBEREASON] Various hotfixes causing doublon and/or missing logs
 
 
 ## [2.15.8] - 2024-07-24


### PR DESCRIPTION
[**API_PARSER**] [**CYBEREASON**]

- Differentiate endpoints timestamps for malwares and malops,
- Add malwares endpoint upper time bound support (to),
- Add check to ensure we're not requesting more than 10k results from API,
- Add check to ensure we're updating the timestamp if no logs during last 24 hours,
- Raise response malops limit from 50 to 1k,