### PR TITLE
[API_PARSER][CYBEREASON] Avoid None evaluation of log objects in format_log for malops

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [API_PARSER] [NETSKOPE] Correctly update the last_collected_timestamp, even when no logs are received
+- [API_PARSER] [CYBEREASON] Avoid None evaluation of log objects in format_log for malops
 
 
 ## [2.22.0] - 2025-02-25

--- a/vulture_os/toolkit/api_parser/cybereason/malop.py
+++ b/vulture_os/toolkit/api_parser/cybereason/malop.py
@@ -169,22 +169,20 @@ class Malop:
         flattened_hostname = []
         flattened_domain = []
 
-        if devices := log.get('devices'):
-            for device in devices:
-                if device['ip'] not in flattened_ip:
-                    flattened_ip.append(device['ip'])
-                if device['nat']['ip'] not in flattened_ip:
-                    flattened_ip.append(device['nat']['ip'])
-                if device['hostname'] not in flattened_hostname:
-                    flattened_hostname.append(device['hostname'])
-                if device['domain'] not in flattened_domain:
-                    flattened_domain.append(device['domain'])
+        for device in log.get('devices', []):
+            if device['ip'] not in flattened_ip:
+                flattened_ip.append(device['ip'])
+            if device['nat']['ip'] not in flattened_ip:
+                flattened_ip.append(device['nat']['ip'])
+            if device['hostname'] not in flattened_hostname:
+                flattened_hostname.append(device['hostname'])
+            if device['domain'] not in flattened_domain:
+                flattened_domain.append(device['domain'])
 
-        if users := log.get('users'):
-            for user in users:
-                domain = user.get('displayName', "").split('\\')[0]
-                if domain and (domain not in flattened_domain):
-                    flattened_domain.append(domain)
+        for user in log.get('users', []):
+            domain = user.get('displayName', "").split('\\')[0]
+            if domain and (domain not in flattened_domain):
+                flattened_domain.append(domain)
 
         if process_details := log.get('process_details'):
             log['formated_process_details'] = self._process_details_flattener(process_details)

--- a/vulture_os/toolkit/api_parser/cybereason/malop.py
+++ b/vulture_os/toolkit/api_parser/cybereason/malop.py
@@ -169,20 +169,22 @@ class Malop:
         flattened_hostname = []
         flattened_domain = []
 
-        for device in log['devices']:
-            if device['ip'] not in flattened_ip:
-                flattened_ip.append(device['ip'])
-            if device['nat']['ip'] not in flattened_ip:
-                flattened_ip.append(device['nat']['ip'])
-            if device['hostname'] not in flattened_hostname:
-                flattened_hostname.append(device['hostname'])
-            if device['domain'] not in flattened_domain:
-                flattened_domain.append(device['domain'])
+        if devices := log.get('devices'):
+            for device in devices:
+                if device['ip'] not in flattened_ip:
+                    flattened_ip.append(device['ip'])
+                if device['nat']['ip'] not in flattened_ip:
+                    flattened_ip.append(device['nat']['ip'])
+                if device['hostname'] not in flattened_hostname:
+                    flattened_hostname.append(device['hostname'])
+                if device['domain'] not in flattened_domain:
+                    flattened_domain.append(device['domain'])
 
-        for user in log['users']:
-            domain = (user['displayName']).split('\\')[0]
-            if domain not in flattened_domain:
-                flattened_domain.append(domain)
+        if users := log.get('users'):
+            for user in users:
+                domain = user.get('displayName', "").split('\\')[0]
+                if domain and (domain not in flattened_domain):
+                    flattened_domain.append(domain)
 
         if process_details := log.get('process_details'):
             log['formated_process_details'] = self._process_details_flattener(process_details)


### PR DESCRIPTION
**[API_PARSER][CYBEREASON]** Avoid None evaluation of log objects (users and devices) in format_log for malops