### PR TITLE
[API_PARSER][GATEWATCHER_ALERTS] Add 'host' field in json logs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [SYSTEM] [SETTINGS] Allow to configure project with django-environ
 - [TESTS] [SYSTEM] Implement Network test cases
 - [TESTS] [WORKFLOW] Implement Workflow test cases
+- [API_PARSER] [GATEWATCHER_ALERTS] Add 'host' field in json logs (requested url's domain)
 ### Removed
 - [TESTS] Remove old 'testing' folder
 ### Changed

--- a/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
+++ b/vulture_os/toolkit/api_parser/gatewatcher_alerts/gatewatcher_alerts.py
@@ -132,6 +132,7 @@ class GatewatcherAlertsParser(ApiParser):
             }
 
     def format_log(self, log):
+        log['host'] = self.gatewatcher_alerts_host
         return json.dumps(log)
 
     def execute(self):


### PR DESCRIPTION
### Added
 - [API_PARSER][GATEWATCHER_ALERTS] Add 'host' field in json logs (requested url's domain)