### PR TITLE
[API_PARSER][WAF_CLOUDFLARE] Fix invalid 'test' time range

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [SYSTEM] [SETTINGS] Use Hostname value from Django settings
 ### Fixed
 - [SYSTEM] [MONGODB] Always refer to settings to connect to mongodb
+- [API_PARSER] [WAF_CLOUDFLARE] Fix invalid time range requested for UTC-* consoles
 
 
 ## [2.22.2] - 2025-03-17

--- a/vulture_os/toolkit/api_parser/waf_cloudflare/waf_cloudflare.py
+++ b/vulture_os/toolkit/api_parser/waf_cloudflare/waf_cloudflare.py
@@ -160,10 +160,12 @@ class WAFCloudflareParser(ApiParser):
         logger.info(f"[{__parser__}]:execute: Parsing done.", extra={'frontend': str(self.frontend)})
 
     def test(self):
+        # Query one second of logs, starting from 24 hours ago
+        # To prevent, for instance, UTC-10 missing logs
         current_time = timezone.now()
         try:
-            logs = list(self.get_logs(logs_from=(current_time - timedelta(seconds=62)),
-                                      logs_to=(current_time - timedelta(seconds=61))))
+            logs = list(self.get_logs(logs_from=(current_time - timedelta(hours=24, seconds=31)),
+                                      logs_to=(current_time - timedelta(hours=24, seconds=1))))
 
             return {
                 "status": True,


### PR DESCRIPTION
### Fixed
 - [API_PARSER][WAF_CLOUDFLARE] Fix invalid time range requested for UTC-* consoles
