### PR TITLE
[CISCO_DUO] Fix doublon logs generated by non-incrementation of last_api_call by one second & prevent non-declaration of since

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [API_PARSER] [WAF_CLOUDFLARE] Avoid querying the API with data from more than a week ago
+- [API_PARSER] [CISCO_DUO] Increment time pointer by 1s at the end of a run to avoid duplicates
 
 
 ## [2.23.0] - 2025-03-28


### PR DESCRIPTION
[CISCO_DUO] Fix doublon logs generated by non-incrementation of last_api_call by one second & prevent non-declaration of since