### PR TITLE
[API_PARSER] [BLACKBERRY_CYLANCE] Wait 60s when we encounter a 429 error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [VULTURED] Delay option on api_request calls
 - [FRONTEND] Rsyslog queue settings
+### Changed
+- [API_PARSER] [BLACKBERRY_CYLANCE] Stop collector earlier and wait for next run when rate-limited by the API
 ### Fixed
 - [API_PARSER] [BEYONDTRUST_REPORTINGS] Fix parsing of support session logs
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [VULTURED] Delay option on api_request calls
 - [FRONTEND] Rsyslog queue settings
+- [API_PARSER] Add Possibility for Collectors to stop early without reporting errors
 ### Changed
 - [API_PARSER] [BLACKBERRY_CYLANCE] Stop collector earlier and wait for next run when rate-limited by the API
 ### Fixed

--- a/vulture_os/gui/crontab/api_clients_parser.py
+++ b/vulture_os/gui/crontab/api_clients_parser.py
@@ -29,6 +29,7 @@ from services.frontend.models import Frontend
 from system.cluster.models import Cluster
 from time import sleep
 from multiprocessing import Process
+from toolkit.api_parser.api_parser import EarlyTerminationWarning
 
 import logging
 logging.config.dictConfig(settings.LOG_SETTINGS)
@@ -59,6 +60,9 @@ def execute_parser(frontend):
             parser.frontend.status[Cluster.get_current_node().name] = "OPEN"
         except Exception as e:
             logger.exception(e)
+    except EarlyTerminationWarning as e:
+        logger.warning(f"API Parser {frontend['name']} (tenant={frontend['tenant_name']}) stopped early: {e}",
+                     extra={'frontend': str(frontend['name'])})
     except Exception as e:
         logger.error(f"API Parser {frontend['name']} (tenant={frontend['tenant_name']}) failure : ",
                      extra={'frontend': str(frontend['name'])})

--- a/vulture_os/toolkit/api_parser/api_parser.py
+++ b/vulture_os/toolkit/api_parser/api_parser.py
@@ -46,6 +46,8 @@ logger = logging.getLogger('api_parser')
 class NodeNotBootstraped(Exception):
     pass
 
+class EarlyTerminationWarning(Warning):
+    pass
 
 class ApiParser:
     def __init__(self, data):

--- a/vulture_os/toolkit/api_parser/blackberry_cylance/blackberry_cylance.py
+++ b/vulture_os/toolkit/api_parser/blackberry_cylance/blackberry_cylance.py
@@ -34,7 +34,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import dateparse, timezone
 
-from toolkit.api_parser.api_parser import ApiParser
+from toolkit.api_parser.api_parser import ApiParser, EarlyTerminationWarning
 
 logging.config.dictConfig(settings.LOG_SETTINGS)
 logger = logging.getLogger('api_parser')
@@ -149,7 +149,7 @@ class BlackberryCylanceParser(ApiParser):
 
                 if response.status_code == 429:
                     logger.warning(f"[{__parser__}]:_execute_query: API Request failed (code 429), stopping this run and waiting for the next", extra={'frontend': str(self.frontend)})
-                    raise BlackberryCylanceAPIError(f"Rate limit exceeded")
+                    raise EarlyTerminationWarning("Rate limit exceeded")
 
                 if response.status_code not in [200, 201]:
                     logger.error(f"[{__parser__}]:_execute_query: Error while getting logs. code: {response.status_code}", extra={'frontend': str(self.frontend)})

--- a/vulture_os/toolkit/api_parser/blackberry_cylance/blackberry_cylance.py
+++ b/vulture_os/toolkit/api_parser/blackberry_cylance/blackberry_cylance.py
@@ -146,6 +146,16 @@ class BlackberryCylanceParser(ApiParser):
                     proxies=self.proxies,
                     verify=self.api_parser_custom_certificate if self.api_parser_custom_certificate else self.api_parser_verify_ssl
                 )
+                # According to the documentation, we have to wait 60s when we encounter a 429 error
+                if response.status_code == 429:
+                    self.evt_stop.wait(60.0)
+                    response = self.session.get(
+                        url,
+                        params=query,
+                        timeout=timeout,
+                        proxies=self.proxies,
+                        verify=self.api_parser_custom_certificate if self.api_parser_custom_certificate else self.api_parser_verify_ssl
+                    )
 
                 if response.status_code not in [200, 201]:
                     logger.error(f"[{__parser__}]:_execute_query: Error while getting logs. code: {response.status_code}", extra={'frontend': str(self.frontend)})

--- a/vulture_os/toolkit/api_parser/blackberry_cylance/blackberry_cylance.py
+++ b/vulture_os/toolkit/api_parser/blackberry_cylance/blackberry_cylance.py
@@ -146,16 +146,10 @@ class BlackberryCylanceParser(ApiParser):
                     proxies=self.proxies,
                     verify=self.api_parser_custom_certificate if self.api_parser_custom_certificate else self.api_parser_verify_ssl
                 )
-                # According to the documentation, we have to wait 60s when we encounter a 429 error
+
                 if response.status_code == 429:
-                    self.evt_stop.wait(60.0)
-                    response = self.session.get(
-                        url,
-                        params=query,
-                        timeout=timeout,
-                        proxies=self.proxies,
-                        verify=self.api_parser_custom_certificate if self.api_parser_custom_certificate else self.api_parser_verify_ssl
-                    )
+                    logger.warning(f"[{__parser__}]:_execute_query: API Request failed (code 429), stopping this run and waiting for the next", extra={'frontend': str(self.frontend)})
+                    raise BlackberryCylanceAPIError(f"Rate limit exceeded")
 
                 if response.status_code not in [200, 201]:
                     logger.error(f"[{__parser__}]:_execute_query: Error while getting logs. code: {response.status_code}", extra={'frontend': str(self.frontend)})


### PR DESCRIPTION
**[API_PARSER] [BLACKBERRY_CYLANCE]** Wait 60s when we encounter a 429 error