### PR TITLE
[FRONTEND][LOG-FORMAT] Adjust http_path of log-format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [API_PARSER] [CROWDSTRIKE] Add identities to fetched information
+### Fixed
+- [LOG_FORMAT] [HAPROXY] Use correct log-format field for haproxy HTTP path only
 
 
 ## [2.30.0]

--- a/vulture_os/services/frontend/models.py
+++ b/vulture_os/services/frontend/models.py
@@ -2258,7 +2258,7 @@ class Frontend(RsyslogQueue, models.Model):
                           "\\\"captured_request_cookie\\\": \\\"%{+E}CC\\\", " \
                           "\\\"captured_response_cookie\\\": \\\"%{+E}CS\\\", " \
                           "\\\"http_method\\\": \\\"%{+E}HM\\\", " \
-                          "\\\"http_path\\\": \\\"%{+E}HP\\\", " \
+                          "\\\"http_path\\\": \\\"%{+E}HPO\\\", " \
                           "\\\"http_get_params\\\": \\\"%{+E}HQ\\\", " \
                           "\\\"http_version\\\": \\\"%{+E}HV\\\", " \
                           "\\\"http_user_agent\\\": \\\"%[capture.req.hdr(0)]\\\", " \


### PR DESCRIPTION
### Fixed
 - [**FRONTEND**] Adjust "http_path" of log-format directive, %HP has changed since HAProxy v2.4