### PR TITLE
fix(cluster): Allow to correctly remove node even if it/redis is inaccessible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- [CLUSTER] [REDIS] Allow to correctly remove node even if it/redis is inaccessible
 
 
 ## [2.27.0] - 2025-06-10


### PR DESCRIPTION
### Fixed
- [CLUSTER] [REDIS] Allow to correctly remove node even if it/redis is inaccessible