### PR TITLE
[API_PARSER][CISCO_MERAKI] Remove duplicated code block and fix timestamp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [API] [X509CERTIFICATE] AssertionError on non-existent certificate
 - [MIGRATIONS] Set missing default values for complex fields in Frontends
+- [API_PARSER] [CISCO_MERAKI] Correctly set and save timestamp after log collection
 
 
 ## [2.28.0] - 2025-06-26

--- a/vulture_os/toolkit/api_parser/cisco_meraki/cisco_meraki.py
+++ b/vulture_os/toolkit/api_parser/cisco_meraki/cisco_meraki.py
@@ -27,7 +27,7 @@ import json
 import logging
 import meraki
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 from django.conf import settings
 from django.utils import timezone
 from toolkit.api_parser.api_parser import ApiParser
@@ -269,34 +269,14 @@ class CiscoMerakiParser(ApiParser):
                 self.update_lock()
 
                 if len(configuration_change_events) > 0:
-                    self.frontend.cisco_meraki_timestamp[f"org{orga['id']}_change_events"] = configuration_change_events[-1]['ts']
+                    last_timestamp = max(configuration_change_events, key=lambda event: event['ts'])['ts']
 
+                    # Add 1 ms to prevent duplicates
+                    last_timestamp_datetime = datetime.strptime(last_timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+                    self.frontend.cisco_meraki_timestamp[f"org{orga['id']}_change_events"] = \
+                        datetime.strftime(last_timestamp_datetime + timedelta(milliseconds=1), "%Y-%m-%dT%H:%M:%S.%fZ")
 
-            if self.cisco_meraki_get_configuration_changes_logs and not self.evt_stop.is_set():
-
-                since = self.frontend.cisco_meraki_timestamp.get(f"org{orga['id']}_change_events", (timezone.now() - timedelta(days=1)).isoformat())
-
-                logger.info(f"[{__parser__}]:execute: Getting organisation {orga['name']} change events since {since} to now", extra={'frontend': str(self.frontend)})
-
-                configuration_change_events = self.get_organization_configuration_change_events(since, orga['id'])
-                # Parsing 1k lines may take some while, so refresh token in Redis before
-                self.update_lock()
-
-                def format_configuration_change_log(log):
-                    log['log_type'] = "configuration_change"
-                    log['organization_id'] = orga['id']
-                    log['organization_name'] = orga['name']
-                    log['timestamp'] = log['ts']
-                    return json.dumps(log)
-
-                logger.info(f"[{__parser__}]:execute: Fetched {len(configuration_change_events)} change events for organisation {orga['name']}", extra={'frontend': str(self.frontend)})
-
-                self.write_to_file([format_configuration_change_log(log) for log in configuration_change_events])
-                # Writting may take some while, so refresh token in Redis
-                self.update_lock()
-
-                if len(configuration_change_events) > 0:
-                    self.frontend.cisco_meraki_timestamp[f"org{orga['id']}_change_events"] = configuration_change_events[-1]['ts']
+                    self.frontend.save(update_fields=["cisco_meraki_timestamp"])
 
 
         logger.info(f"[{__parser__}]:execute: Parser ending", extra={'frontend': str(self.frontend)})


### PR DESCRIPTION
Somehow, the last change to this parser for configuration changes handling was applied two times on the file.

Also, the events did not seem to be ordered, so last event wasn't the most recent timestamp. I also added one millisecond to not query the same event multiple times.

### Fixed
- [API_PARSER][CISCO_MERAKI] Remove duplicated code block and fix timestamp

