### PR TITLE
fix(middlewares): wrongly report node not bootstrapped

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [GUI] [NETIF] Show CARP information for addresses imported from rc.conf (support for externally managed CARP)
 ### Fixed
 - [SCRIPTS] [REFRESH_NIC] Correctly parse complex rc.conf ifconfig entries
+- [MIDDLEWARE] [OS] Wrongly report that node is not bootstrapped
 
 
 ## [2.33.1] - 2025-10-29

--- a/vulture_os/gui/context_processors.py
+++ b/vulture_os/gui/context_processors.py
@@ -25,6 +25,7 @@ __doc__ = ''
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.utils import DatabaseError
 
 from applications.apps import Apps
 from authentication.authentication import Authentication
@@ -57,6 +58,9 @@ def admin_media(request):
 
     except (ObjectDoesNotExist, AssertionError):
         node_name = ""
+    except DatabaseError as e:
+        node_name = ""
+        logger.error(f"context_processors:admin_media: MongoDB error: {e}")
 
     menu = (System().menu, Service().menu, Authentication().menu, Portal().menu, Darwin().menu, Apps().menu, Workflows().menu)
     results = {
@@ -65,7 +69,7 @@ def admin_media(request):
         'CURRENT_NODE': node_name,
         'DEV_MODE': settings.DEV_MODE,
         'TITLE': settings.HOSTNAME,
-        'COLLAPSE': request.session.get('collapse')
+        'COLLAPSE': False if not node_name else request.session.get('collapse')
     }
 
     return results

--- a/vulture_os/gui/middlewares/os.py
+++ b/vulture_os/gui/middlewares/os.py
@@ -48,10 +48,12 @@ class OsMiddleware:
         # Code to be executed for each request before
         # the view (and later middleware) are called.
         if not self.node_bootstrapped:
-            return render(request, "gui/not_install.html", {
-                'TITLE': 'VultureOS',
-                'WALLPAPER': static("img/VultureOS_wallpaper.png")
-            })
+            self.node_bootstrapped = Cluster.is_node_bootstrapped()
+            if not self.node_bootstrapped:
+                return render(request, "gui/not_install.html", {
+                    'TITLE': 'VultureOS',
+                    'WALLPAPER': static("img/VultureOS_wallpaper.png")
+                })
 
         # No authentication for API (protected later by decorators)
         if request.path_info.startswith('/api/'):


### PR DESCRIPTION
### Fixed
- [MIDDLEWARE] [OS] Wrongly report that node is not bootstrapped