### PR TITLE
fix(carp): Add missing PF rule for inter-cluster CARP synchronization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [LOG_FORWARDER] [SENTINEL] Add new Log Forwarder to Vulture GUI
 ### Fixed
 - [API_PARSER] [GATEWATCHER_ALERTS] Reduce the page size to 10 to avoid timeout errors
+- [PF] [CONF] Add missing CARP rule to allow inter-cluster broadcasting and enable correct MASTER/BACKUP switch
 
 
 ## [2.29.1] - 2025-08-22

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [API_PARSER] [GATEWATCHER_ALERTS] Reduce the page size to 10 to avoid timeout errors
 - [PF] [CONF] Add missing CARP rule to allow inter-cluster broadcasting and enable correct MASTER/BACKUP switch
+- [NET] [CARP] Correctly clean system configurations when removing some interface(s) from an existing CARP conf
 
 
 ## [2.29.1] - 2025-08-22

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [API_PARSER] [GATEWATCHER_ALERTS] Reduce the page size to 10 to avoid timeout errors
 - [PF] [CONF] Add missing CARP rule to allow inter-cluster broadcasting and enable correct MASTER/BACKUP switch
 - [NET] [CARP] Correctly clean system configurations when removing some interface(s) from an existing CARP conf
+- [NET] [CARP] Correctly use existing carp password and priorities for added interface(s) on an existing CARP conf
 
 
 ## [2.29.1] - 2025-08-22

--- a/vulture_os/services/config/pf.conf
+++ b/vulture_os/services/config/pf.conf
@@ -219,7 +219,10 @@ pass out quick all keep state
 {{ node.pf_custom_config }}
 #######################
 
-#pass in quick proto udp from any to port 123
+{% for interface in carp_allowed_interfaces -%}
+# Allowed incoming CARP traffic on {{interface}}
+pass quick on {{interface}} proto carp
+{% endfor %}
 
 
 # Incoming traffic on Admin GUI

--- a/vulture_os/services/pf/models.py
+++ b/vulture_os/services/pf/models.py
@@ -29,7 +29,7 @@ from djongo import models
 
 # Django project imports
 from applications.reputation_ctx.models import DATABASES_PATH
-from system.cluster.models import Cluster, Node
+from system.cluster.models import Cluster, Node, NetworkInterfaceCard
 from toolkit.network.network import JAIL_ADDRESSES
 from toolkit.network.network import get_sanitized_proxy
 
@@ -55,6 +55,9 @@ class PFSettings(models.Model):
         """
         return {
             'nodes': Node.objects.exclude(name=settings.HOSTNAME),
+            'carp_allowed_interfaces': set(NetworkInterfaceCard.objects.filter(
+                networkaddress__carp_vhid__gt=0,
+                node__name=settings.HOSTNAME).values_list('dev', flat=True)),
             'global_config': Cluster.get_global_config(),
             'jail_addresses': JAIL_ADDRESSES,
             'databases_path': DATABASES_PATH,

--- a/vulture_os/system/netif/views.py
+++ b/vulture_os/system/netif/views.py
@@ -23,6 +23,7 @@ __email__ = "contact@vultureproject.org"
 __doc__ = 'Network View'
 
 
+from django.db.models import Max
 from django.http import HttpResponseForbidden, HttpResponseRedirect, JsonResponse
 from system.cluster.models import NetworkAddress, NetworkAddressNIC, NetworkInterfaceCard, Cluster
 from system.netif.form import NetIfForm
@@ -96,6 +97,10 @@ def netif_edit(request, object_id=None, api=False):
 
                 priority = priority + 50
         else:
+            # Get current highest priority and increment for next interface card
+            priority = netif.networkaddressnic_set.aggregate(Max('carp_priority'))['carp_priority__max'] + 50
+            # Get already existing CARP password
+            pwd = netif.networkaddressnic_set.first().carp_passwd
 
             """ Add new NIC, if any """
             if api:

--- a/vulture_os/system/netif/views.py
+++ b/vulture_os/system/netif/views.py
@@ -123,7 +123,10 @@ def netif_edit(request, object_id=None, api=False):
                 """ If the current nic is not in the new config anymore:
                 Remove it from NetworkAddressNIC """
                 if str(current_networkadress_nic.nic.pk) not in nic_list:
+                    node_of_removed_nic = current_networkadress_nic.nic.node
+                    rc_confs = netif.rc_config()
                     current_networkadress_nic.delete()
+                    node_of_removed_nic.api_request('toolkit.network.network.remove_netif_configs', rc_confs)
 
 
         """ Write permanent network configuration on disk """


### PR DESCRIPTION
### Fixed
- [PF] [CONF] Add missing CARP rule to allow inter-cluster broadcasting and enable correct MASTER/BACKUP switch
- [NET] [CARP] Correctly clean system configurations when removing some interface(s) from an existing CARP conf
- [NET] [CARP] Correctly use existing carp password and priorities for added interface(s) on an existing CARP conf