### PR TITLE
[API_PARSER][SENTINEL_ONE] Fix double slashes issues

### DIFF
--- a/vulture_os/toolkit/api_parser/sentinel_one/sentinel_one.py
+++ b/vulture_os/toolkit/api_parser/sentinel_one/sentinel_one.py
@@ -41,13 +41,13 @@ class SentinelOneAPIError(Exception):
 
 
 class SentinelOneParser(ApiParser):
-    LOGIN_URI_TOKEN = "/web/api/v2.1/users/login/by-api-token"
+    LOGIN_URI_TOKEN = "web/api/v2.1/users/login/by-api-token"
     LOGIN_URI = "/web/api/v2.1/users/login"
     VERSION_URI = "/web/api/v2.1/system/info"
     ACCOUNTS = "/web/api/v2.1/accounts"
     SITES = "/web/api/v2.1/sites"
     AGENTS = "/web/api/v2.1/agents"
-    THREATS = "/web/api/v2.1/threats"
+    THREATS = "web/api/v2.1/threats"
     POLICY_BY_SITE = "/web/api/v2.1/sites/{id}/policy"
     ACTIVITIES = "web/api/v2.1/activities"
 
@@ -59,7 +59,7 @@ class SentinelOneParser(ApiParser):
     def __init__(self, data):
         super().__init__(data)
 
-        self.sentinel_one_host = data["sentinel_one_host"]
+        self.sentinel_one_host = data["sentinel_one_host"].rstrip("/")
         if not self.sentinel_one_host.startswith('https://'):
             self.sentinel_one_host = f"https://{self.sentinel_one_host}"
 


### PR DESCRIPTION
There were some double slashes in URL requested and in some fields like observer.name

### Fixed
- [API_PARSER][SENTINEL_ONE] Fix double slashes issues