### PR TITLE
fix(system_node): remove unused netaddr after node deletion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- [SYSTEM] [NETWORK] Remaining NetworkAddress after Node deletion
 
 
 ## [2.35.8] - 2026-06-15


### PR DESCRIPTION
### Fixed
- [SYSTEM] [NETWORK] Remaining NetworkAddress after Node deletion