### PR TITLE
fix(system_pki): prohibit spaces in x509_certificate name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- [SYSTEM] [PKI] Prohibit spaces in X509Certificate name
 
 
 ## [2.35.8] - 2026-06-15

--- a/vulture_os/system/config/models.py
+++ b/vulture_os/system/config/models.py
@@ -193,7 +193,7 @@ def delete_conf(logger, filenames):
 
     allowed_files_regex = ["{}/\w+_\d+\.html".format(ERROR_TPL_PATH),
                            "{}/.*\.(mmdb|netset|lookup)".format(REPUTATION_CTX_DB_PATH),
-                           "{}/[\w\_\-\.]+-\d+\.(chain|crt|pem|key|pub)".format(CERT_PATH),
+                           "{}/[\w\_\-\. ]+-\d+\.(chain|crt|pem|key|pub)".format(CERT_PATH),
                            "{}/parser_[0-9]+\.rb".format(RSYSLOG_PATH),
                            "{}/f[\w-]+/f[\w-]+_[0-9]+.conf".format(DARWIN_PATH)]
 

--- a/vulture_os/system/pki/form.py
+++ b/vulture_os/system/pki/form.py
@@ -54,6 +54,10 @@ class X509InternalCertificateForm(ModelForm):
             'cn': TextInput(attrs={'class': 'form-control'})
         }
 
+    def clean_name(self):
+        """ Prohibit spaces in X509Certificate name, replace them by _ """
+        return self.cleaned_data['name'].replace(' ', '_')
+
 
 class X509ExternalCertificateForm(ModelForm):
 
@@ -74,6 +78,10 @@ class X509ExternalCertificateForm(ModelForm):
             'crl_uri': TextInput(attrs={'class': 'form-control'}),
             'crl': Textarea(attrs={'class': 'form-control'})
         }
+
+    def clean_name(self):
+        """ Prohibit spaces in X509Certificate name, replace them by _ """
+        return self.cleaned_data['name'].replace(' ', '_')
 
     def clean_cert(self):
         """ Ensure cert is a valid PEM certificate


### PR DESCRIPTION
### Fixed
- [SYSTEM] [PKI] Prohibit spaces in X509Certificate name